### PR TITLE
corrected inconsistent rendering by applying the css style in the bef…

### DIFF
--- a/fpo-web/src/components/status/ApplicationStatus.vue
+++ b/fpo-web/src/components/status/ApplicationStatus.vue
@@ -73,6 +73,10 @@ export default {
       
     }
   },
+  beforeCreate() {
+    const Survey = SurveyVue;
+    surveyEnv.setCss(Survey);
+  },
   created() {
     // To be fetched from db
     this.inProgressApplications.push(

--- a/fpo-web/src/components/steps/common-information/Information.vue
+++ b/fpo-web/src/components/steps/common-information/Information.vue
@@ -23,14 +23,16 @@ export default {
     survey.showQuestionNumbers = "off";
     survey.showNavigationButtons = false;
     surveyEnv.setGlossaryMarkdown(survey);
+
     return {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-
+  },
+  created() {
     if (this.step.result.yourInformationSurvey) {
       this.survey.data = this.step.result.yourInformationSurvey;
     }

--- a/fpo-web/src/components/steps/common-information/otherPartyComponent/OtherPartySurvey.vue
+++ b/fpo-web/src/components/steps/common-information/otherPartyComponent/OtherPartySurvey.vue
@@ -75,7 +75,7 @@ export default {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
   },

--- a/fpo-web/src/components/steps/get-started/Questionnaire.vue
+++ b/fpo-web/src/components/steps/get-started/Questionnaire.vue
@@ -60,10 +60,11 @@ export default {
       survey: survey,
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-
+  },
+  created() {
     if (this.step.result.questionnaireSurvey) {
       this.survey.data = this.step.result.questionnaireSurvey;
     }

--- a/fpo-web/src/components/steps/protectionOrder/About.vue
+++ b/fpo-web/src/components/steps/protectionOrder/About.vue
@@ -33,10 +33,11 @@ export default {
       selectedPOOrder: null
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-    
+  },
+  created() {
     if (this.step.result.aboutPOSurvey){
       this.survey.data = this.step.result.aboutPOSurvey;
     }  

--- a/fpo-web/src/components/steps/protectionOrder/Background.vue
+++ b/fpo-web/src/components/steps/protectionOrder/Background.vue
@@ -27,10 +27,11 @@ export default {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-   
+  },
+  created() {
     if (this.step.result.backgroundSurvey){
       this.survey.data = this.step.result.backgroundSurvey;
     }  

--- a/fpo-web/src/components/steps/protectionOrder/ProtectionFromWhom.vue
+++ b/fpo-web/src/components/steps/protectionOrder/ProtectionFromWhom.vue
@@ -61,9 +61,11 @@ export default {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
+  },
+  created() {
     if (this.step.result.protectionWhomSurvey){
       this.survey.data = this.step.result.protectionWhomSurvey;
     }

--- a/fpo-web/src/components/steps/protectionOrder/Urgency.vue
+++ b/fpo-web/src/components/steps/protectionOrder/Urgency.vue
@@ -53,10 +53,11 @@ export default {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-
+  },
+  created() {
     if (this.step.result.urgencySurvey) {
       this.survey.data = this.step.result.urgencySurvey;
     }

--- a/fpo-web/src/components/steps/protectionOrder/YourStory.vue
+++ b/fpo-web/src/components/steps/protectionOrder/YourStory.vue
@@ -42,10 +42,11 @@ export default {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-    
+  },
+  created() {
     if (this.step.result.yourStory){
       this.survey.data = this.step.result.yourStory;
     }  

--- a/fpo-web/src/components/steps/protectionOrder/safetyNeeds/NoContact.vue
+++ b/fpo-web/src/components/steps/protectionOrder/safetyNeeds/NoContact.vue
@@ -55,10 +55,11 @@ export default {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-   
+  },
+  created() {
     if (this.step.result.noContactSurvey){
       this.survey.data = this.step.result.noContactSurvey;
     }   

--- a/fpo-web/src/components/steps/protectionOrder/safetyNeeds/NoGo.vue
+++ b/fpo-web/src/components/steps/protectionOrder/safetyNeeds/NoGo.vue
@@ -40,10 +40,11 @@ export default {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-    
+  },
+  created() {
     if (this.step.result.noGoSurvey){
       this.survey.data = this.step.result.noGoSurvey;
     }   

--- a/fpo-web/src/components/steps/protectionOrder/safetyNeeds/RemovePerson.vue
+++ b/fpo-web/src/components/steps/protectionOrder/safetyNeeds/RemovePerson.vue
@@ -55,10 +55,11 @@ export default {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-
+  },
+  created() {
     if (this.step.result.removeSurvey){
       this.survey.data = this.step.result.removeSurvey;
     }

--- a/fpo-web/src/components/steps/protectionOrder/safetyNeeds/WeaponsFirearms.vue
+++ b/fpo-web/src/components/steps/protectionOrder/safetyNeeds/WeaponsFirearms.vue
@@ -55,10 +55,11 @@ export default {
       survey: survey
     };
   },
-  created() {
+  beforeCreate() {
     const Survey = SurveyVue;
     surveyEnv.setCss(Survey);
-   
+  },
+  created() {
     if (this.step.result.weaponsSurvey){
       this.survey.data = this.step.result.weaponsSurvey;
     }  


### PR DESCRIPTION
…oreCreate lifecycle hook

Problem:
Incorrect rendering of 'Your Information' on first load and and inconsistent on subsequent renders

Cause:
Timing issue ... the css settings for the surveys were being set at created() time, and depended on the function call surveyEnv.setCss(Survey); .. therefore the data was loading before the styles.  

Fix: I moved that piece of code into the beforeCreate() hook, so that the page loads before the data.  I replicated the fix for all files that call surveyEnv.setCss(Survey);