### PR TITLE
JSON schema tools for survey versioning

### DIFF
--- a/api/api/management/commands/validatesteps.py
+++ b/api/api/management/commands/validatesteps.py
@@ -1,0 +1,31 @@
+import json
+import subprocess
+
+from django.conf import settings
+from django.db import migrations
+from jsonschema import validate
+from api.models import Application
+from django.core.management.base import BaseCommand, CommandError
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('file_path')
+        
+    def handle(self, *args, **options):
+        file_path =  options['file_path']
+        print(f'Ensure generate_schema was recently ran, so your schema is up to date.')
+        print(f'Reading schema from {file_path}')
+        f = open(file_path,)
+        schema = json.load(f)
+        f.close()
+        for application in Application.objects.all():
+            steps_json = json.loads(
+                settings.ENCRYPTOR.decrypt(
+                    application.key_id, application.steps
+                ).decode("utf-8")
+            )
+            #print(json.dumps(steps_json, indent=4).replace('\r\n',''))
+            print(f'Validating steps schema for application Id: {application.id}')
+            validate(instance= {"steps" : steps_json}, schema=schema)
+            print(f'Validation successful for application Id: {application.id}')
+        

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,23 @@
+.DS_Store
+node_modules
+/dist
+
+# local env files
+.env.local
+.env.*.local
+
+fake_data.json
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/tools/generate_fake_data
+++ b/tools/generate_fake_data
@@ -1,0 +1,1 @@
+node generate_fake_data.js $1

--- a/tools/generate_fake_data.js
+++ b/tools/generate_fake_data.js
@@ -1,0 +1,24 @@
+const jsf = require('json-schema-faker');
+
+const fs = require('fs');
+
+const version = process.argv[2];
+if (!version) {
+	version = "1.0";
+}
+
+const fileName = `schema_${version}.json`;
+console.log(`Generating by using ${fileName}`);
+let rawdata = fs.readFileSync(fileName);
+let schema = JSON.parse(rawdata);
+
+jsf.option({fixedProbabilities: true, alwaysFakeOptionals: true, refDepthMin: 50, refDepthMax: 50});
+
+jsf.resolve(schema).then(sample => {
+  try {
+	  console.log(`Generated fake data from schema: ${fileName}`);
+  const data = fs.writeFileSync(`fake_data.json`, JSON.stringify(sample, null, 4))
+} catch (err) {
+  console.error(err)
+}
+});

--- a/tools/generate_schema
+++ b/tools/generate_schema
@@ -1,0 +1,2 @@
+#!/bin/sh
+./node_modules/.bin/ts-json-schema-generator --path '../web/src/types/**/*.ts' --type 'applicationStepOnlyInfoType' > schema.json

--- a/tools/local_migration_tester.py
+++ b/tools/local_migration_tester.py
@@ -1,0 +1,126 @@
+# This tests it locally, with faked data.
+import subprocess
+import json
+import os
+from jsf import JSF
+from jsonschema import validate, ValidationError
+
+# Unfortunately can't easily use Typescript for this, because we need Python to interface with Django.
+# The plus side is we validate which should catch any typos.
+
+def migrate(data):
+    steps = data['steps']
+    for step in steps:
+        result = step.get('result')
+        if result is None:
+            continue
+        result['aboutSurvey'] = result.get('aboutPOSurvey')
+        result.pop('aboutPOSurvey', None)
+        result['poQuestionnaireSurvey'] = result.get('questionnaireSurvey')
+        result.pop('questionnaireSurvey', None)     
+
+        if result.get('poQuestionnaireSurvey') is not None:
+            # Use existing data or use defaults.
+            result['poQuestionnaireSurvey']['questions'] = result['poQuestionnaireSurvey'].get('questions', [])
+            result['poQuestionnaireSurvey']['pageName'] = result['poQuestionnaireSurvey'].get('pageName', '')
+            result['poQuestionnaireSurvey']['currentStep'] = result['poQuestionnaireSurvey'].get('currentStep', 0)
+            result['poQuestionnaireSurvey']['currentPage'] = result['poQuestionnaireSurvey'].get('currentPage', 0)
+            if result['poQuestionnaireSurvey'].get('data') is None:
+                result['poQuestionnaireSurvey']['data'] = {}
+                result['poQuestionnaireSurvey']['data']['orderType'] = result['poQuestionnaireSurvey'].get('orderType')
+                result['poQuestionnaireSurvey'].pop('orderType', None)
+                result['poQuestionnaireSurvey']['data']['explanationQualifying'] = result['poQuestionnaireSurvey'].get('explanationQualifying')
+                result['poQuestionnaireSurvey'].pop('explanationQualifying', None)
+                result['poQuestionnaireSurvey']['data']['unsafe'] = result['poQuestionnaireSurvey'].get('unsafe')
+                result['poQuestionnaireSurvey'].pop('unsafe', None)
+                result['poQuestionnaireSurvey']['data']['familyUnsafe'] = result['poQuestionnaireSurvey'].get('familyUnsafe')
+                result['poQuestionnaireSurvey'].pop('familyUnsafe', None)
+                result['poQuestionnaireSurvey']['data']['PORConfirmed'] = result['poQuestionnaireSurvey'].get('PORConfirmed')
+                result['poQuestionnaireSurvey'].pop('PORConfirmed', None)
+
+        result['protectionFromWhomSurvey'] = result.get('protectionWhomSurvey')
+        result.pop('protectionWhomSurvey', None)
+        result['yourinformationPOSurvey'] = result.get('yourInformationSurveyPO')
+        result.pop('yourInformationSurveyPO', None)
+        result['yourStorySurvey'] = result.get('yourStory')
+        result.pop('yourStory', None)
+        result['removePersonSurvey'] = result.get('removeSurvey')
+        result.pop('removeSurvey', None)
+        result['weaponsFirearmsSurvey'] = result.get('weaponsSurvey')
+        result.pop('weaponsSurvey', None)
+
+        result['safetyCheckSurvey'] = result.get('safetySurvey')
+        result.pop('safetySurvey', None)
+        if result.get('safetyCheckSurvey') is not None:
+            result['safetyCheckSurvey']['questions'] = result['safetyCheckSurvey'].get('questions', [])
+            result['safetyCheckSurvey']['pageName'] = result['safetyCheckSurvey'].get('pageName', '')
+            result['safetyCheckSurvey']['currentStep'] = result['safetyCheckSurvey'].get('currentStep', 0)
+            result['safetyCheckSurvey']['currentPage'] = result['safetyCheckSurvey'].get('currentPage', 0)
+            if result['safetyCheckSurvey'].get('data') is None:
+                result['safetyCheckSurvey']['data'] = {}
+                result['safetyCheckSurvey']['data']['unsafe'] = result['safetyCheckSurvey']['unsafe']
+                result['safetyCheckSurvey'].pop('unsafe', None)
+
+
+        result['flmQuestionnaireSurvey'] = result.get('flmSelectedForm')
+        result.pop('flmSelectedForm', None)
+        result['childrenInfoSurvey'] = result.get('childData')
+        result.pop('childData', None)
+        result['flmAdditionalDocumentsSurvey'] = result.get('flmAdditionalDocsSurvey')
+        result.pop('flmAdditionalDocsSurvey', None)
+        result['bestInterestsOfChildSurvey'] = result.get('bestInterestOfChildSurvey')
+        result.pop('bestInterestOfChildSurvey', None)
+        result['otherParentingArrangementsSurvey'] = result.get('parentalArrangementsSurvey')
+        result.pop('parentalArrangementsSurvey', None)
+        result['childSupportCurrentArrangementsSurvey'] = result.get('childSupportCurrentArrangementSurvey')
+        result.pop('childSupportCurrentArrangementSurvey', None)
+        result['incomeAndEarningPotentialSurvey'] = result.get('childSupportIncomeEarningSurvey')
+        result.pop('childSupportIncomeEarningSurvey', None)
+        result['aboutContactWithChildOrderSurvey'] = result.get('aboutContactWithChildSurvey')
+        result.pop('aboutContactWithChildSurvey', None)
+        result['contactWithChildBestInterestsOfChildSurvey'] = result.get('contactWithChildBestInterestOfChildSurvey')
+        result.pop('contactWithChildBestInterestOfChildSurvey', None)
+        result['contactWithChildOrderSurvey'] = result.get('contactOrderSurvey')
+        result.pop('contactOrderSurvey', None)
+        result['guardianOfChildSurvey'] = result.get('GuardianOfChildSurvey')
+        result.pop('GuardianOfChildSurvey', None)
+        result['guardianOfChildBestInterestsOfChildSurvey'] = result.get('GuardianOfChildBestInterestOfChildSurvey')
+        result.pop('GuardianOfChildBestInterestOfChildSurvey', None)
+        result['filingOptionsSurvey'] = result.get('filingOptions')
+        result.pop('filingOptions', None)
+    return steps
+
+
+def validate_by_schema(migrated_data):
+        validate_state = 'successful.'
+        try:
+            validate(instance= {"steps" : migrated_data}, schema=schema)
+        except ValidationError as err:
+            print(err)
+            validate_state = 'failed.'
+        print(f'Validation {validate_state}')
+
+old_version = '1.0'
+new_version = '1.1'
+print('This application reads the old schema, generates data, does the migration and validates using the new schema.')
+print('Hopefully this will prevent data loss when executing migrations due to application changes.')
+print(f'Old version: {old_version}')
+print(f'New version: {new_version}')
+print(f'Ensure generate_schema was recently ran, so schema-{new_version}.json is up to date.')
+print(f'Reading from schema_{new_version}.json')
+f = open(f'schema_{new_version}.json',)
+schema = json.load(f)
+f.close()
+max_runs = 20
+for run in range(0,max_runs):   
+    print(f'Generating fake data, migrating and validating migration {run+1} of {max_runs}')
+    if os.name == 'nt':
+        #This may require admin on windows.
+        subprocess.run(['C:\\Program Files\\Git\\git-bash.exe', '-l', 'generate_fake_data', old_version])
+    else:
+        subprocess.run(['generate_fake_data', old_version], shell=True)
+    f = open('fake_data.json',)
+    fake_data = json.load(f)
+    f.close()
+    migrated_data = migrate(fake_data)
+    validate_by_schema(migrated_data)

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,0 +1,223 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@types/json-schema": {
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
+		"commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"drange": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+			"integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"format-util": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
+			"integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"glob": {
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"json-schema-faker": {
+			"version": "github:seeker25/json-schema-faker#1b5d78918ed7d9dd91c0ff5d352bedde7eb94372",
+			"from": "github:seeker25/json-schema-faker",
+			"requires": {
+				"json-schema-ref-parser": "^6.1.0",
+				"jsonpath-plus": "^3.0.0",
+				"randexp": "^0.5.3",
+				"yaml": "^1.10.2"
+			}
+		},
+		"json-schema-ref-parser": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
+			"integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^3.12.1",
+				"ono": "^4.0.11"
+			}
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "~0.0.0"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsonpath-plus": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-3.0.0.tgz",
+			"integrity": "sha512-WQwgWEBgn+SJU1tlDa/GiY5/ngRpa9yrSj8n4BYPHcwoxTDaMEaYCHMOn42hIHHDd3CrUoRr3+HpsK0hCKoxzA=="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"ono": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+			"integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+			"requires": {
+				"format-util": "^1.0.3"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"randexp": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+			"integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+			"requires": {
+				"drange": "^1.0.2",
+				"ret": "^0.2.0"
+			}
+		},
+		"ret": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+			"integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"ts-json-schema-generator": {
+			"version": "0.93.0",
+			"resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-0.93.0.tgz",
+			"integrity": "sha512-JYacSIgw4KqsOXF/zRSY4pE/v6jUk7aMDXhwK5MdopN0UeKH58TRZHrQADy9uxTf78jqUfFLzARQKNOb9H+jVQ==",
+			"requires": {
+				"@types/json-schema": "^7.0.7",
+				"commander": "^7.2.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"glob": "^7.1.7",
+				"json-stable-stringify": "^1.0.1",
+				"typescript": "~4.3.2"
+			}
+		},
+		"typescript": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+			"integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw=="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+		}
+	}
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,7 @@
+{
+	"type": "commonjs",
+	"dependencies": {
+		"json-schema-faker": "seeker25/json-schema-faker#d664487",
+		"ts-json-schema-generator": "^0.93.0"
+	}
+}

--- a/tools/readme.txt
+++ b/tools/readme.txt
@@ -1,0 +1,12 @@
+To validate the JSON schema against data in the database:
+1. npm install
+2. Run generate_schema
+3. Rename schema file to schema_(version).
+4. cd /api/ -> Run python manage.py validatesteps '../tools/schema_(version).json' (with database environment variables set, much like migrations.)
+5. Run generate_fake_data (optional)
+
+Alternatively for local testing:
+run local_migration_tester.py. 
+It will generate fake data based on the old schema.
+Execute a python migration function.
+Validate the new data using the new schema.

--- a/tools/schema_1.0.json
+++ b/tools/schema_1.0.json
@@ -1,0 +1,4135 @@
+{
+	"$ref": "#/definitions/applicationStepOnlyInfoType",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"ExistingOrderInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"fileNumber": {
+					"type": "string"
+				},
+				"filingLocation": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"filingLocation",
+				"fileNumber"
+			],
+			"type": "object"
+		},
+		"aboutChildSupportChangesDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"listOfSituations": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"orderDescription": {
+					"type": "string"
+				},
+				"orderStartDateReason": {
+					"type": "string"
+				},
+				"orderStartingDate": {
+					"$ref": "#/definitions/orderStartingDateInfoType"
+				}
+			},
+			"required": [
+				"orderDescription",
+				"orderStartingDate",
+				"orderStartDateReason",
+				"listOfSituations"
+			],
+			"type": "object"
+		},
+		"aboutChildSupportChangesSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutChildSupportChangesDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutChildSupportOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"listOfChildren": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"listOfSupportPayors": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"numberOf19yrsChild": {
+					"type": "number"
+				},
+				"over19Details": {
+					"items": {
+						"$ref": "#/definitions/over19DetailsInfoType"
+					},
+					"type": "array"
+				},
+				"paymentRequestStartingDate": {
+					"$ref": "#/definitions/paymentRequestStartingDateInfoType"
+				},
+				"paymentRequestStartingDateWhy": {
+					"type": "string"
+				},
+				"payorEarnsHigh": {
+					"type": "string"
+				},
+				"supportChildOver19": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[10]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[1]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[2]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[3]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[4]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[5]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[6]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[7]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[8]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[9]": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"numberOf19yrsChild",
+				"listOfSupportPayors",
+				"over19Details",
+				"payorEarnsHigh",
+				"listOfChildren",
+				"supportChildOver19",
+				"paymentRequestStartingDate",
+				"paymentRequestStartingDateWhy"
+			],
+			"type": "object"
+		},
+		"aboutChildSupportOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutChildSupportOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutContactWithChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"childrenRequireContactChoices": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"conditionsDescription": {
+					"type": "string"
+				},
+				"contactTypeChoices": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"contactTypeChoicesComment": {
+					"type": "string"
+				},
+				"inPersonDetails": {
+					"type": "string"
+				},
+				"lastContactDate": {
+					"type": "string"
+				},
+				"placeConditions": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"lastContactDate",
+				"placeConditions"
+			],
+			"type": "object"
+		},
+		"aboutContactWithChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutContactWithChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutExistingChildSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementDate": {
+					"type": "string"
+				},
+				"agreementDifferenceType": {
+					"type": "string"
+				},
+				"changesSinceAgreement": {
+					"type": "string"
+				},
+				"changesSinceOrderList": {
+					"$ref": "#/definitions/changesSinceOrderListInfoType"
+				},
+				"orderDate": {
+					"type": "string"
+				},
+				"orderDifferenceType": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"aboutExistingChildSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutExistingChildSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutExistingSpousalSupportOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"changesSinceOrder": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"changesSinceOrder"
+			],
+			"type": "object"
+		},
+		"aboutExistingSpousalSupportOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutExistingSpousalSupportOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutPOSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutPOSurveydataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutPOSurveydataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingCourt": {
+					"type": "string"
+				},
+				"ExistingFileNumber": {
+					"type": "string"
+				},
+				"changePOattachment": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"dateOfPO": {
+					"type": "string"
+				},
+				"inCourtForPO": {
+					"type": "string"
+				},
+				"kindofPartyIbPO": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"terminateDateOfPO": {
+					"type": "string"
+				},
+				"terminatePOattachment": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"whatChangesNeeded": {
+					"type": "string"
+				},
+				"whyChangesNeeded": {
+					"type": "string"
+				},
+				"whyNotInCourt": {
+					"type": "string"
+				},
+				"whyTerminatePO": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"ExistingCourt",
+				"ExistingFileNumber",
+				"inCourtForPO",
+				"kindofPartyIbPO"
+			],
+			"type": "object"
+		},
+		"aboutParentingArrangementsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementDate": {
+					"type": "string"
+				},
+				"agreementDifferenceType": {
+					"type": "string"
+				},
+				"changesSinceAgreement": {
+					"type": "string"
+				},
+				"changesSinceOrder": {
+					"type": "string"
+				},
+				"existingType": {
+					"type": "string"
+				},
+				"orderDate": {
+					"type": "string"
+				},
+				"orderDifferenceType": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"existingType"
+			],
+			"type": "object"
+		},
+		"aboutParentingArrangementsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutParentingArrangementsDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutSpousalSupportOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"howToPaySpousalSupport": {
+					"$ref": "#/definitions/howToPaySpousalSupportInfoType"
+				}
+			},
+			"required": [
+				"howToPaySpousalSupport"
+			],
+			"type": "object"
+		},
+		"aboutSpousalSupportOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutSpousalSupportOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"addressInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"city": {
+					"type": "string"
+				},
+				"country": {
+					"type": "string"
+				},
+				"postcode": {
+					"type": "string"
+				},
+				"state": {
+					"type": "string"
+				},
+				"street": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"street",
+				"city",
+				"state",
+				"country",
+				"postcode"
+			],
+			"type": "object"
+		},
+		"allAnotherAdultsSharingResiInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"anotherAdultSharingResiName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"anotherAdultSharingResiRelation": {
+					"type": "string"
+				},
+				"anotheradultSharingResiDOB": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"allOtherChilderenInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"childDOB": {
+					"type": "string"
+				},
+				"childLivingWith": {
+					"type": "string"
+				},
+				"childName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"childRelationshipWithOther": {
+					"type": "string"
+				},
+				"childRelationshipWithProtected": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"childName",
+				"childDOB",
+				"childRelationshipWithProtected",
+				"childRelationshipWithOther",
+				"childLivingWith"
+			],
+			"type": "object"
+		},
+		"allchildrenInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"childDOB": {
+					"type": "string"
+				},
+				"childLivingWith": {
+					"type": "string"
+				},
+				"childName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"childRelationship": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"applicationStepOnlyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"steps": {
+					"items": {
+						"$ref": "#/definitions/stepInfoType"
+					},
+					"type": "array"
+				},
+				"types_version": {
+					"const": "1.0",
+					"type": "string"
+				}
+			},
+			"required": [
+				"steps"
+			],
+			"type": "object"
+		},
+		"backgroundSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingOrders": {
+					"type": "string"
+				},
+				"PartiesHasOtherChilderen": {
+					"type": "string"
+				},
+				"allOtherChilderen": {
+					"items": {
+						"$ref": "#/definitions/allOtherChilderenInfoType"
+					},
+					"type": "array"
+				},
+				"concernForNotObeying": {
+					"type": "string"
+				},
+				"culturalExplain": {
+					"type": "string"
+				},
+				"dateOfMarriagePO": {
+					"type": "string"
+				},
+				"describeActionsByPolice": {
+					"type": "string"
+				},
+				"describeCirumstancesPO": {
+					"type": "string"
+				},
+				"describeDisobeyOrder": {
+					"type": "string"
+				},
+				"desrcibeSWAction": {
+					"type": "string"
+				},
+				"existingPOOrders": {
+					"type": "string"
+				},
+				"explainReasonsForConcern": {
+					"type": "string"
+				},
+				"explainReasonsPO": {
+					"type": "string"
+				},
+				"howPartiesRelated": {
+					"type": "string"
+				},
+				"isSeperatedPO": {
+					"type": "string"
+				},
+				"likeToAddCulturalExplanation": {
+					"type": "string"
+				},
+				"liveTogetherPODate": {
+					"type": "string"
+				},
+				"mentalHealthConcernPO": {
+					"type": "string"
+				},
+				"otherPartyDisobeyOrder": {
+					"type": "string"
+				},
+				"reportedConcernsToPolice": {
+					"type": "string"
+				},
+				"reportedConcernsToSW": {
+					"type": "string"
+				},
+				"riskOfViolencePO": {
+					"type": "string"
+				},
+				"separationDate": {
+					"type": "string"
+				},
+				"werePOPartiesMarried": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"howPartiesRelated",
+				"werePOPartiesMarried",
+				"isSeperatedPO",
+				"likeToAddCulturalExplanation",
+				"mentalHealthConcernPO",
+				"riskOfViolencePO",
+				"existingPOOrders",
+				"otherPartyDisobeyOrder",
+				"concernForNotObeying",
+				"reportedConcernsToPolice",
+				"reportedConcernsToSW"
+			],
+			"type": "object"
+		},
+		"backgroundSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/backgroundSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"calculatingChildSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"attachingCalculations": {
+					"type": "string"
+				},
+				"whyNotAttachingCalculations": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"attachingCalculations"
+			],
+			"type": "object"
+		},
+		"calculatingChildSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/calculatingChildSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"calculatingSpousalSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"attachingCalculations": {
+					"type": "string"
+				},
+				"whyNotAttachingCalculations": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"attachingCalculations"
+			],
+			"type": "object"
+		},
+		"calculatingSpousalSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/calculatingSpousalSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"cancelGuardianDetailInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"date": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"nameOther": {
+					"type": "string"
+				},
+				"relationship": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"name",
+				"nameOther",
+				"date",
+				"relationship"
+			],
+			"type": "object"
+		},
+		"changesSinceOrderListInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"arrangementsChangedComment": {
+					"type": "string"
+				},
+				"checked": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"expensesChangedComment": {
+					"type": "string"
+				},
+				"newInformationComment": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"checked"
+			],
+			"type": "object"
+		},
+		"childDetailsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ack": {
+					"type": "string"
+				},
+				"additionalInfo": {
+					"type": "string"
+				},
+				"additionalInfoDetails": {
+					"type": "string"
+				},
+				"currentLiving": {
+					"type": "string"
+				},
+				"currentLivingComment": {
+					"type": "string"
+				},
+				"dob": {
+					"type": "string"
+				},
+				"id": {
+					"type": "number"
+				},
+				"name": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"opRelation": {
+					"type": "string"
+				},
+				"relation": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"name",
+				"dob",
+				"relation",
+				"opRelation",
+				"currentLiving"
+			],
+			"type": "object"
+		},
+		"childDetailsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"items": {
+						"$ref": "#/definitions/childDetailsDataInfoType"
+					},
+					"type": "array"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"childSupportCurrentArrangementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applicantTimeType": {
+					"type": "string"
+				},
+				"applicantTimeWithChildExplanation": {
+					"type": "string"
+				},
+				"currentArrangmentExplanation": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"applicantTimeWithChildExplanation",
+				"applicantTimeType",
+				"currentArrangmentExplanation"
+			],
+			"type": "object"
+		},
+		"childSupportCurrentArrangementSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/childSupportCurrentArrangementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"childSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applicantGuardianType": {
+					"type": "string"
+				},
+				"otherParty[0]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[10]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[1]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[2]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[3]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[4]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[5]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[6]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[7]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[8]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[9]GuardianType": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"applicantGuardianType"
+			],
+			"type": "object"
+		},
+		"childSupportIncomeEarningDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"factsExplanation": {
+					"type": "string"
+				},
+				"knowFacts": {
+					"type": "string"
+				},
+				"knowIncome": {
+					"type": "string"
+				},
+				"otherPartyIncome": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"knowIncome",
+				"knowFacts"
+			],
+			"type": "object"
+		},
+		"childSupportIncomeEarningSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/childSupportIncomeEarningDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"childSupportOrderAgreementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingResponsibilityType": {
+					"type": "string"
+				},
+				"existingResponsibilityTypeComment": {
+					"type": "string"
+				},
+				"existingType": {
+					"type": "string"
+				},
+				"filedWithDirector": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"existingType"
+			],
+			"type": "object"
+		},
+		"childSupportOrderAgreementSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/childSupportOrderAgreementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"childSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/childSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"childrenSupportExpenseFieldInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"key": {
+					"type": "string"
+				},
+				"label": {
+					"type": "string"
+				},
+				"tdClass": {
+					"type": "string"
+				},
+				"thClass": {
+					"type": "string"
+				},
+				"thStyle": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"key",
+				"label",
+				"tdClass",
+				"thClass",
+				"thStyle"
+			],
+			"type": "object"
+		},
+		"contactInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"email": {
+					"type": "string"
+				},
+				"fax": {
+					"type": "string"
+				},
+				"phone": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"phone",
+				"fax",
+				"email"
+			],
+			"type": "object"
+		},
+		"contactOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementDate": {
+					"type": "string"
+				},
+				"agreementDifferenceType": {
+					"type": "string"
+				},
+				"changesSinceAgreement": {
+					"type": "string"
+				},
+				"changesSinceOrder": {
+					"type": "string"
+				},
+				"existingType": {
+					"type": "string"
+				},
+				"orderDate": {
+					"type": "string"
+				},
+				"orderDifferenceType": {
+					"type": "string"
+				},
+				"roleType": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"roleType",
+				"existingType"
+			],
+			"type": "object"
+		},
+		"contactOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/contactOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"contactWithChildBestInterestOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingChildBestInterestDescription": {
+					"type": "string"
+				},
+				"newChildBestInterestDescription": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"contactWithChildBestInterestOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/contactWithChildBestInterestOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"contactWithChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"parentGuardianApplicant": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"parentGuardianApplicant"
+			],
+			"type": "object"
+		},
+		"contactWithChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/contactWithChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportAgreementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementDate": {
+					"type": "string"
+				},
+				"agreementDifferenceType": {
+					"type": "string"
+				},
+				"changesReasoning": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"agreementDate",
+				"changesReasoning",
+				"agreementDifferenceType"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportAgreementSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/existingSpousalSupportAgreementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportFinalOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"changesSinceOrderList": {
+					"$ref": "#/definitions/spousalChangesSinceOrderListInfoType"
+				},
+				"orderDate": {
+					"type": "string"
+				},
+				"orderDifferenceType": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"orderDate",
+				"changesSinceOrderList",
+				"orderDifferenceType"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportFinalOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/existingSpousalSupportFinalOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportOrderAgreementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingType": {
+					"type": "string"
+				},
+				"filedWithDirector": {
+					"type": "string"
+				},
+				"fillOutForm": {
+					"type": "string"
+				},
+				"reviewableTerm": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"existingType"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportOrderAgreementSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/existingSpousalSupportOrderAgreementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"filingLocationDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingCourt": {
+					"type": "string"
+				},
+				"ExistingFamilyCase": {
+					"type": "string"
+				},
+				"ExistingFileNumber": {
+					"type": "string"
+				},
+				"ExplanationCourtLocation": {
+					"type": "boolean"
+				},
+				"MetEarlyResolutionRequirements": {
+					"type": "string"
+				},
+				"changePOattachment": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"dateOfPO": {
+					"type": "string"
+				},
+				"earlyResolutionRegistry": {
+					"type": "boolean"
+				},
+				"familyEducationProgram": {
+					"type": "boolean"
+				},
+				"familyJusticeRegistry": {
+					"type": "boolean"
+				},
+				"inCourtForPO": {
+					"type": "string"
+				},
+				"kindofPartyIbPO": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"registryLocationReason": {
+					"type": "string"
+				},
+				"terminateDateOfPO": {
+					"type": "string"
+				},
+				"terminatePOattachment": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"whatChangesNeeded": {
+					"type": "string"
+				},
+				"whyChangesNeeded": {
+					"type": "string"
+				},
+				"whyNotInCourt": {
+					"type": "string"
+				},
+				"whyTerminatePO": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"ExistingCourt",
+				"ExistingFileNumber",
+				"inCourtForPO",
+				"kindofPartyIbPO"
+			],
+			"type": "object"
+		},
+		"filingLocationSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/filingLocationDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"flmAdditionalDocsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"criminalChecked": {
+					"type": "string"
+				},
+				"isFilingAdditionalDocs": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"isFilingAdditionalDocs",
+				"criminalChecked"
+			],
+			"type": "object"
+		},
+		"flmAdditionalDocsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/flmAdditionalDocsDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"flmBackgroundSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingOrdersFLM": {
+					"type": "string"
+				},
+				"culturalExplain": {
+					"type": "string"
+				},
+				"dateOfMarriagePO": {
+					"type": "string"
+				},
+				"existingOrdersListFLM": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"existingPOOrders": {
+					"type": "string"
+				},
+				"howPartiesRelated": {
+					"type": "string"
+				},
+				"isSeperated": {
+					"type": "string"
+				},
+				"likeToAddCulturalExplanation": {
+					"type": "string"
+				},
+				"listOfSpouses": {
+					"type": "string"
+				},
+				"liveTogetherPODate": {
+					"type": "string"
+				},
+				"separationDate": {
+					"type": "string"
+				},
+				"werePOPartiesMarried": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"ExistingOrdersFLM",
+				"existingOrdersListFLM",
+				"existingPOOrders",
+				"howPartiesRelated",
+				"werePOPartiesMarried",
+				"liveTogetherPODate",
+				"dateOfMarriagePO",
+				"isSeperated",
+				"separationDate",
+				"likeToAddCulturalExplanation",
+				"culturalExplain"
+			],
+			"type": "object"
+		},
+		"flmBackgroundSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/flmBackgroundSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"flmSelectedFormInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"guardianOfChildBestInterestOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"cancelGuradianChildBestInterest": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"cancelGuradianChildBestInterest"
+			],
+			"type": "object"
+		},
+		"guardianOfChildBestInterestOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/guardianOfChildBestInterestOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"guardianOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applicationType": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"cancelGuardianDetails": {
+					"items": {
+						"$ref": "#/definitions/cancelGuardianDetailInfoType"
+					},
+					"type": "array"
+				},
+				"childrenList": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"applicationType"
+			],
+			"type": "object"
+		},
+		"guardianOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/guardianOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"howToPaySpousalSupportInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"lumpsumAmount": {
+					"type": "string"
+				},
+				"monthlyAmount": {
+					"type": "string"
+				},
+				"monthlyEndDate": {
+					"type": "string"
+				},
+				"monthlyStartDate": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"selected"
+			],
+			"type": "object"
+		},
+		"indigenousAncestryOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ServeAcknowledgement": {
+					"type": "string"
+				},
+				"indigenousAncestry": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"indigenousChild": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"indigenousChild"
+			],
+			"type": "object"
+		},
+		"indigenousAncestryOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/indigenousAncestryOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"lawyerStatementInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"clientName": {
+					"type": "string"
+				},
+				"lawyerName": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"lawyerName",
+				"clientName"
+			],
+			"type": "object"
+		},
+		"nameInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"first": {
+					"type": "string"
+				},
+				"last": {
+					"type": "string"
+				},
+				"middle": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"first",
+				"middle",
+				"last"
+			],
+			"type": "object"
+		},
+		"noContactSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"needCommunication": {
+					"type": "string"
+				},
+				"reasonForCommunication": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"reasonForCommunicationComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"needCommunication"
+			],
+			"type": "object"
+		},
+		"noContactSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/noContactSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"noGoSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"RespondentNoGo": {
+					"type": "string"
+				},
+				"RespondentNoGoPlaces": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"RespondentNoGoPlacesComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"RespondentNoGo"
+			],
+			"type": "object"
+		},
+		"noGoSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/noGoSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"orderStartingDateInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				},
+				"startingDate": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"startingDate",
+				"selected"
+			],
+			"type": "object"
+		},
+		"otherPartyCommonSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"items": {
+						"$ref": "#/definitions/otherPartyInfoType"
+					},
+					"type": "array"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"otherPartyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"address": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"contactInfo": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"dateOfLivedTogether": {
+					"type": "string"
+				},
+				"dateOfMarriage": {
+					"type": "string"
+				},
+				"dateSeparated": {
+					"type": "string"
+				},
+				"dob": {
+					"type": "string"
+				},
+				"id": {
+					"type": "number"
+				},
+				"knowDob": {
+					"type": "string"
+				},
+				"livedTogether": {
+					"type": "string"
+				},
+				"married": {
+					"type": "string"
+				},
+				"name": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"opRelation": {
+					"type": "string"
+				},
+				"separated": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"name",
+				"knowDob",
+				"address",
+				"contactInfo"
+			],
+			"type": "object"
+		},
+		"over19DetailsInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"reasonForSupport": {
+					"$ref": "#/definitions/reasonForSupportInfoType"
+				}
+			},
+			"required": [
+				"name",
+				"reasonForSupport"
+			],
+			"type": "object"
+		},
+		"pageInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"active": {
+					"type": "boolean"
+				},
+				"clickable": {
+					"type": "boolean"
+				},
+				"key": {
+					"type": "string"
+				},
+				"label": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"progress": {
+					"type": "number"
+				}
+			},
+			"required": [
+				"key",
+				"label",
+				"progress",
+				"active"
+			],
+			"type": "object"
+		},
+		"parentalArrangementsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"parentalArrangements": {
+					"type": "string"
+				},
+				"parentalArrangementsDescription": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"parentalArrangements",
+				"parentalArrangementsDescription"
+			],
+			"type": "object"
+		},
+		"parentalArrangementsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentalArrangementsDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentalResponsibilitiesDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExplainResponsibilities": {
+					"type": "string"
+				},
+				"allResponsibilitiesOrder": {
+					"type": "string"
+				},
+				"childrenRequestedResponsibilities": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"parentalResponsibilitiesOrder": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"parentalResponsibilitiesSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentalResponsibilitiesDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingArrangementChangesDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingOrderChangeOtherTermsDescription": {
+					"type": "string"
+				},
+				"existingOrderChangeParentalResponsibilitiesDescription": {
+					"type": "string"
+				},
+				"existingOrderChangeParentingTimeConditionsDescription": {
+					"type": "string"
+				},
+				"existingOrderChangeParentingTimeDescription": {
+					"type": "string"
+				},
+				"orderChangeList": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"orderChangeList"
+			],
+			"type": "object"
+		},
+		"parentingArrangementChangesSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingArrangementChangesDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingArrangementsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyingGuardianApplicant": {
+					"type": "string"
+				},
+				"guardianApplicant": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"guardianApplicant",
+				"applyingGuardianApplicant"
+			],
+			"type": "object"
+		},
+		"parentingArrangementsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingArrangementsDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingArrangementsbestInterestOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingParentingArrangementsChildBestInterestDescription": {
+					"type": "string"
+				},
+				"newParentingArrangementsChildBestInterestDescription": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"parentingArrangementsbestInterestOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingArrangementsbestInterestOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingOrderAgreementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyingGuardianApplicant": {
+					"type": "string"
+				},
+				"guardianApplicant": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"guardianApplicant",
+				"applyingGuardianApplicant"
+			],
+			"type": "object"
+		},
+		"parentingOrderAgreementSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingOrderAgreementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingTimeDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ApplicantParentingTimeConditions": {
+					"type": "string"
+				},
+				"RespondentParentingTimeConditions": {
+					"type": "string"
+				},
+				"applicantDesiredParentingTime": {
+					"type": "string"
+				},
+				"conditionedApplicantParentingTime": {
+					"type": "string"
+				},
+				"conditionedRespondentParentingTime": {
+					"type": "string"
+				},
+				"parentingTimeOrder": {
+					"type": "string"
+				},
+				"respondentDesiredParentingTime": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"parentingTimeOrder"
+			],
+			"type": "object"
+		},
+		"parentingTimeSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingTimeDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"pathwayCompletedInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementEnfrc": {
+					"type": "boolean"
+				},
+				"caseMgmt": {
+					"type": "boolean"
+				},
+				"childReloc": {
+					"type": "boolean"
+				},
+				"familyLawMatter": {
+					"type": "boolean"
+				},
+				"priorityParenting": {
+					"type": "boolean"
+				},
+				"protectionOrder": {
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"protectionOrder",
+				"familyLawMatter",
+				"caseMgmt",
+				"priorityParenting",
+				"childReloc",
+				"agreementEnfrc"
+			],
+			"type": "object"
+		},
+		"paymentRequestStartingDateInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				},
+				"startingDate": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"startingDate",
+				"selected"
+			],
+			"type": "object"
+		},
+		"paymentScheduleInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"monthlyAmount": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"monthlyAmount",
+				"selected"
+			],
+			"type": "object"
+		},
+		"poFilingLocationSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingCourt": {
+					"type": "string"
+				},
+				"ExistingFamilyCase": {
+					"type": "string"
+				},
+				"ExistingFileNumber": {
+					"type": "string"
+				},
+				"ExplanationCourtLocation": {
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"ExistingFamilyCase",
+				"ExplanationCourtLocation"
+			],
+			"type": "object"
+		},
+		"poFilingLocationSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/poFilingLocationSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"poQuestionnaireSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"PORConfirmed": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"explanationQualifying": {
+					"type": "boolean"
+				},
+				"familyUnsafe": {
+					"type": "string"
+				},
+				"orderType": {
+					"type": "string"
+				},
+				"unsafe": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"orderType"
+			],
+			"type": "object"
+		},
+		"protectionWhomSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ApplicantNeedsProtection": {
+					"type": "string"
+				},
+				"RespondentAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"RespondentContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"RespondentDOB": {
+					"type": "string"
+				},
+				"RespondentDOBExact": {
+					"type": "string"
+				},
+				"RespondentName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"allAnotherAdultsSharingResi": {
+					"items": {
+						"$ref": "#/definitions/allAnotherAdultsSharingResiInfoType"
+					},
+					"type": "array"
+				},
+				"allchildren": {
+					"items": {
+						"$ref": "#/definitions/allchildrenInfoType"
+					},
+					"type": "array"
+				},
+				"anotherAdultDOB": {
+					"type": "string"
+				},
+				"anotherAdultName": {
+					"type": "string"
+				},
+				"anotherAdultPO": {
+					"type": "string"
+				},
+				"anotherAdultReasonForPO": {
+					"type": "string"
+				},
+				"anotherAdultSharingResi": {
+					"type": "string"
+				},
+				"childPO": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"RespondentName",
+				"RespondentDOBExact",
+				"RespondentAddress",
+				"RespondentContact",
+				"ApplicantNeedsProtection",
+				"childPO"
+			],
+			"type": "object"
+		},
+		"protectionWhomSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/protectionWhomSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"questionInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"inputType": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"title": {
+					"type": "string"
+				},
+				"value": {}
+			},
+			"required": [
+				"name",
+				"value",
+				"title"
+			],
+			"type": "object"
+		},
+		"reasonForSupportInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"disability": {
+					"type": "boolean"
+				},
+				"illness": {
+					"type": "boolean"
+				},
+				"student": {
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"illness",
+				"disability",
+				"student"
+			],
+			"type": "object"
+		},
+		"removeSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"RespondentLiveTogether": {
+					"type": "string"
+				},
+				"needPolice": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"needPoliceComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"RespondentLiveTogether",
+				"needPolice"
+			],
+			"type": "object"
+		},
+		"removeSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/removeSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"requiredDocumentsInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementEnfrc": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"caseMgmt": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"childReloc": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"familyLawMatter": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"priorityParenting": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"protectionOrder": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				}
+			},
+			"type": "object"
+		},
+		"requiredReminderInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"reminder": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"required": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"required",
+				"reminder"
+			],
+			"type": "object"
+		},
+		"resultInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"GuardianOfChildBestInterestOfChildSurvey": {
+					"$ref": "#/definitions/guardianOfChildBestInterestOfChildSurveyInfoType"
+				},
+				"GuardianOfChildSurvey": {
+					"$ref": "#/definitions/guardianOfChildSurveyInfoType"
+				},
+				"aboutChildSupportChangesSurvey": {
+					"$ref": "#/definitions/aboutChildSupportChangesSurveyInfoType"
+				},
+				"aboutChildSupportOrderSurvey": {
+					"$ref": "#/definitions/aboutChildSupportOrderSurveyInfoType"
+				},
+				"aboutContactWithChildSurvey": {
+					"$ref": "#/definitions/aboutContactWithChildSurveyInfoType"
+				},
+				"aboutExistingChildSupportSurvey": {
+					"$ref": "#/definitions/aboutExistingChildSupportSurveyInfoType"
+				},
+				"aboutExistingSpousalSupportOrderSurvey": {
+					"$ref": "#/definitions/aboutExistingSpousalSupportOrderSurveyInfoType"
+				},
+				"aboutPOSurvey": {
+					"$ref": "#/definitions/aboutPOSurveyInfoType"
+				},
+				"aboutParentingArrangementsSurvey": {
+					"$ref": "#/definitions/aboutParentingArrangementsSurveyInfoType"
+				},
+				"aboutSpousalSupportOrderSurvey": {
+					"$ref": "#/definitions/aboutSpousalSupportOrderSurveyInfoType"
+				},
+				"applicantName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"backgroundSurvey": {
+					"$ref": "#/definitions/backgroundSurveyInfoType"
+				},
+				"bestInterestOfChildSurvey": {
+					"$ref": "#/definitions/parentingArrangementsbestInterestOfChildSurveyInfoType"
+				},
+				"calculatingChildSupportSurvey": {
+					"$ref": "#/definitions/calculatingChildSupportSurveyInfoType"
+				},
+				"calculatingSpousalSupportSurvey": {
+					"$ref": "#/definitions/calculatingSpousalSupportSurveyInfoType"
+				},
+				"childBestInterestAcknowledgement": {
+					"type": "boolean"
+				},
+				"childData": {
+					"$ref": "#/definitions/childDetailsSurveyInfoType"
+				},
+				"childSupportCurrentArrangementSurvey": {
+					"$ref": "#/definitions/childSupportCurrentArrangementSurveyInfoType"
+				},
+				"childSupportIncomeEarningSurvey": {
+					"$ref": "#/definitions/childSupportIncomeEarningSurveyInfoType"
+				},
+				"childSupportOrderAgreementSurvey": {
+					"$ref": "#/definitions/childSupportOrderAgreementSurveyInfoType"
+				},
+				"childSupportSurvey": {
+					"$ref": "#/definitions/childSupportSurveyInfoType"
+				},
+				"contactOrderSurvey": {
+					"$ref": "#/definitions/contactOrderSurveyInfoType"
+				},
+				"contactWithChildBestInterestOfChildSurvey": {
+					"$ref": "#/definitions/contactWithChildBestInterestOfChildSurveyInfoType"
+				},
+				"contactWithChildSurvey": {
+					"$ref": "#/definitions/contactWithChildSurveyInfoType"
+				},
+				"existingOrders": {
+					"items": {
+						"$ref": "#/definitions/ExistingOrderInfoType"
+					},
+					"type": "array"
+				},
+				"existingSpousalSupportAgreementSurvey": {
+					"$ref": "#/definitions/existingSpousalSupportAgreementSurveyInfoType"
+				},
+				"existingSpousalSupportFinalOrderSurvey": {
+					"$ref": "#/definitions/existingSpousalSupportFinalOrderSurveyInfoType"
+				},
+				"existingSpousalSupportOrderAgreementSurvey": {
+					"$ref": "#/definitions/existingSpousalSupportOrderAgreementSurveyInfoType"
+				},
+				"filingLocationSurvey": {
+					"$ref": "#/definitions/filingLocationSurveyInfoType"
+				},
+				"filingOptions": {},
+				"flmAdditionalDocsSurvey": {
+					"$ref": "#/definitions/flmAdditionalDocsSurveyInfoType"
+				},
+				"flmBackgroundSurvey": {
+					"$ref": "#/definitions/flmBackgroundSurveyInfoType"
+				},
+				"flmSelectedForm": {
+					"$ref": "#/definitions/flmSelectedFormInfoType"
+				},
+				"indigenousAncestryOfChildSurvey": {
+					"$ref": "#/definitions/indigenousAncestryOfChildSurveyInfoType"
+				},
+				"noContactSurvey": {
+					"$ref": "#/definitions/noContactSurveyInfoType"
+				},
+				"noGoSurvey": {
+					"$ref": "#/definitions/noGoSurveyInfoType"
+				},
+				"otherPartyCommonSurvey": {
+					"$ref": "#/definitions/otherPartyCommonSurveyInfoType"
+				},
+				"otherPartySurvey": {
+					"$ref": "#/definitions/otherPartyCommonSurveyInfoType"
+				},
+				"parentalArrangementsSurvey": {
+					"$ref": "#/definitions/parentalArrangementsSurveyInfoType"
+				},
+				"parentalResponsibilitiesSurvey": {
+					"$ref": "#/definitions/parentalResponsibilitiesSurveyInfoType"
+				},
+				"parentingArrangementChangesSurvey": {
+					"$ref": "#/definitions/parentingArrangementChangesSurveyInfoType"
+				},
+				"parentingArrangementsSurvey": {
+					"$ref": "#/definitions/parentingArrangementsSurveyInfoType"
+				},
+				"parentingOrderAgreementSurvey": {
+					"$ref": "#/definitions/parentingOrderAgreementSurveyInfoType"
+				},
+				"parentingTimeSurvey": {
+					"$ref": "#/definitions/parentingTimeSurveyInfoType"
+				},
+				"pathwayCompleted": {
+					"$ref": "#/definitions/pathwayCompletedInfoType"
+				},
+				"poFilingLocationSurvey": {
+					"$ref": "#/definitions/poFilingLocationSurveyInfoType"
+				},
+				"protectedChildName": {
+					"items": {
+						"$ref": "#/definitions/allchildrenInfoType"
+					},
+					"type": "array"
+				},
+				"protectedPartyName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"protectionWhomSurvey": {
+					"$ref": "#/definitions/protectionWhomSurveyInfoType"
+				},
+				"questionnaireSurvey": {
+					"$ref": "#/definitions/poQuestionnaireSurveyInfoType"
+				},
+				"removeSurvey": {
+					"$ref": "#/definitions/removeSurveyInfoType"
+				},
+				"requiredDocuments": {
+					"$ref": "#/definitions/requiredDocumentsInfoType"
+				},
+				"respondents": {
+					"items": {
+						"$ref": "#/definitions/nameInfoType"
+					},
+					"type": "array"
+				},
+				"respondentsCommon": {
+					"items": {
+						"$ref": "#/definitions/nameInfoType"
+					},
+					"type": "array"
+				},
+				"respondentsPO": {
+					"items": {
+						"$ref": "#/definitions/nameInfoType"
+					},
+					"type": "array"
+				},
+				"safetySurvey": {
+					"$ref": "#/definitions/safetySurveyInfoType"
+				},
+				"selectedForms": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"selectedPOOrder": {
+					"$ref": "#/definitions/selectedPOOrderInfoType"
+				},
+				"specialAndExtraordinaryExpensesSurvey": {
+					"$ref": "#/definitions/specialAndExtraordinaryExpensesSurveyInfoType"
+				},
+				"spousalSupportIncomeAndEarningPotentialSurvey": {
+					"$ref": "#/definitions/spousalSupportIncomeAndEarningPotentialSurveyInfoType"
+				},
+				"spousalSupportSurvey": {
+					"$ref": "#/definitions/spousalSupportSurveyInfoType"
+				},
+				"supportingDocumentForm4": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				},
+				"undueHardshipSurvey": {
+					"$ref": "#/definitions/undueHardshipSurveyInfoType"
+				},
+				"unpaidChildSupportSurvey": {
+					"$ref": "#/definitions/unpaidChildSupportSurveyInfoType"
+				},
+				"unpaidSpousalSupportSurvey": {
+					"$ref": "#/definitions/unpaidSpousalSupportSurveyInfoType"
+				},
+				"urgencySurvey": {
+					"$ref": "#/definitions/urgencySurveyInfoType"
+				},
+				"weaponsSurvey": {
+					"$ref": "#/definitions/weaponsSurveyInfoType"
+				},
+				"yourInformationSurvey": {
+					"$ref": "#/definitions/yourInformationSurveyInfoType"
+				},
+				"yourInformationSurveyPO": {
+					"$ref": "#/definitions/yourInformationSurveyPOInfoType"
+				},
+				"yourStory": {
+					"$ref": "#/definitions/yourStoryInfoType"
+				}
+			},
+			"type": "object"
+		},
+		"safetySurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"unsafe": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"unsafe"
+			],
+			"type": "object"
+		},
+		"selectedPOOrderInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/poQuestionnaireSurveyInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"anyOf": [
+						{
+							"items": {
+								"$ref": "#/definitions/questionInfoType"
+							},
+							"type": "array"
+						},
+						{
+							"type": "null"
+						}
+					]
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"specialAndExtraordinaryExpensesDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyForExtraordinaryExpenses": {
+					"type": "string"
+				},
+				"childrenSupportExpenseFields": {
+					"items": {
+						"$ref": "#/definitions/childrenSupportExpenseFieldInfoType"
+					},
+					"type": "array"
+				},
+				"childrenSupportExpenseItem": {
+					"items": {},
+					"type": "array"
+				}
+			},
+			"required": [
+				"applyForExtraordinaryExpenses"
+			],
+			"type": "object"
+		},
+		"specialAndExtraordinaryExpensesSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/specialAndExtraordinaryExpensesDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"spousalChangesSinceOrderListInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"checked": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"myEmploymentChangedComment": {
+					"type": "string"
+				},
+				"myHouseholdChangedComment": {
+					"type": "string"
+				},
+				"newInformationComment": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				},
+				"partyEmploymentChangedComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"myEmploymentChangedComment",
+				"partyEmploymentChangedComment",
+				"myHouseholdChangedComment",
+				"newInformationComment",
+				"otherComment",
+				"checked"
+			],
+			"type": "object"
+		},
+		"spousalPaymentScheduleInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"monthlyAmount": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"selected"
+			],
+			"type": "object"
+		},
+		"spousalSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentSupport": {
+					"type": "string"
+				},
+				"listOfReasons": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"listOfSupportPayors": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"listOfSupportPayors",
+				"currentSupport",
+				"listOfReasons"
+			],
+			"type": "object"
+		},
+		"spousalSupportIncomeAndEarningPotentialDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"factsExplanation": {
+					"type": "string"
+				},
+				"incomeAmount": {
+					"type": "string"
+				},
+				"incomeInfo": {
+					"type": "string"
+				},
+				"knowFacts": {
+					"type": "string"
+				},
+				"knowIncome": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"incomeInfo",
+				"knowIncome",
+				"knowFacts"
+			],
+			"type": "object"
+		},
+		"spousalSupportIncomeAndEarningPotentialSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/spousalSupportIncomeAndEarningPotentialDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"spousalSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/spousalSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"stepInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"active": {
+					"type": "boolean"
+				},
+				"currentPage": {
+					"type": "number"
+				},
+				"icon": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string"
+				},
+				"label": {
+					"type": "string"
+				},
+				"lastUpdate": {
+					"anyOf": [
+						{
+							"format": "date-time",
+							"type": "string"
+						},
+						{
+							"type": "null"
+						}
+					]
+				},
+				"name": {
+					"type": "string"
+				},
+				"pages": {
+					"items": {
+						"$ref": "#/definitions/pageInfoType"
+					},
+					"type": "array"
+				},
+				"result": {
+					"$ref": "#/definitions/resultInfoType"
+				},
+				"type": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"label",
+				"icon",
+				"currentPage",
+				"active",
+				"lastUpdate"
+			],
+			"type": "object"
+		},
+		"undueHardshipDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"changeAmount": {
+					"type": "string"
+				},
+				"hardshipReasons": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"hardshipReasonsComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"changeAmount",
+				"hardshipReasons"
+			],
+			"type": "object"
+		},
+		"undueHardshipSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/undueHardshipDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"unpaidChildSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyToReduce": {
+					"type": "string"
+				},
+				"paymentSchedule": {
+					"$ref": "#/definitions/paymentScheduleInfoType"
+				},
+				"reduceAmount": {
+					"type": "string"
+				},
+				"unPaidAmount": {
+					"type": "string"
+				},
+				"unpaid": {
+					"type": "string"
+				},
+				"whyReduceAmount": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"unpaid"
+			],
+			"type": "object"
+		},
+		"unpaidChildSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/unpaidChildSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"unpaidSpousalSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyToReduce": {
+					"type": "string"
+				},
+				"paymentSchedule": {
+					"$ref": "#/definitions/spousalPaymentScheduleInfoType"
+				},
+				"reduceAmount": {
+					"type": "string"
+				},
+				"unPaidAmount": {
+					"type": "string"
+				},
+				"unpaid": {
+					"type": "string"
+				},
+				"whyReduceAmount": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"unpaid"
+			],
+			"type": "object"
+		},
+		"unpaidSpousalSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/unpaidSpousalSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"urgencySurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"PORNoNotice": {
+					"type": "string"
+				},
+				"PORWhyNoNotice": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"PORNoNotice"
+			],
+			"type": "object"
+		},
+		"urgencySurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/urgencySurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"weaponsSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"RespondentFirearms": {
+					"type": "string"
+				},
+				"RespondentFirearmsYes": {
+					"type": "string"
+				},
+				"RespondentNoWeapons": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"RespondentWeapons": {
+					"type": "string"
+				},
+				"RespondentWeaponsYes": {
+					"type": "string"
+				},
+				"firearmsReason": {
+					"type": "string"
+				},
+				"firearmsYesReason": {
+					"type": "string"
+				},
+				"weaponsReasons": {
+					"type": "string"
+				},
+				"weaponsYesReason": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"RespondentFirearms",
+				"RespondentFirearmsYes",
+				"RespondentWeapons",
+				"RespondentWeaponsYes"
+			],
+			"type": "object"
+		},
+		"weaponsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/weaponsSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"yourInformationDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ApplicantAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"ApplicantContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"ApplicantDOB": {
+					"type": "string"
+				},
+				"ApplicantName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"ApplicantOccupation": {
+					"type": "string"
+				},
+				"ExplanationServiceAddress": {
+					"type": "boolean"
+				},
+				"Lawyer": {
+					"type": "string"
+				},
+				"LawyerAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"LawyerContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"LawyerFillingOut": {
+					"type": "string"
+				},
+				"LawyerName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"lawyerStatement": {
+					"$ref": "#/definitions/lawyerStatementInfoType"
+				}
+			},
+			"required": [
+				"ApplicantName",
+				"ApplicantDOB",
+				"Lawyer"
+			],
+			"type": "object"
+		},
+		"yourInformationSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/yourInformationDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"yourInformationSurveyPODataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ApplicantAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"ApplicantContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"ApplicantDOB": {
+					"type": "string"
+				},
+				"ApplicantName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"ApplicantOccupation": {
+					"type": "string"
+				},
+				"ExplanationServiceAddress": {
+					"type": "boolean"
+				},
+				"Lawyer": {
+					"type": "string"
+				},
+				"LawyerAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"LawyerContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"LawyerName": {
+					"$ref": "#/definitions/nameInfoType"
+				}
+			},
+			"required": [
+				"ApplicantName",
+				"ApplicantDOB",
+				"Lawyer"
+			],
+			"type": "object"
+		},
+		"yourInformationSurveyPOInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/yourInformationSurveyPODataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"yourStoryDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"isFamilyViolence": {
+					"type": "string"
+				},
+				"isNoneExplainedConcerns": {
+					"type": "string"
+				},
+				"noneExplainedConcerns": {
+					"type": "string"
+				},
+				"recentIncidentWithChild": {
+					"type": "string"
+				},
+				"recentIncidents": {
+					"type": "string"
+				},
+				"whatViolence": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"isFamilyViolence",
+				"isNoneExplainedConcerns",
+				"recentIncidents"
+			],
+			"type": "object"
+		},
+		"yourStoryInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/yourStoryDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		}
+	}
+}

--- a/tools/schema_1.1.json
+++ b/tools/schema_1.1.json
@@ -1,0 +1,4197 @@
+{
+	"$ref": "#/definitions/applicationStepOnlyInfoType",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"ExistingOrderInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"fileNumber": {
+					"type": "string"
+				},
+				"filingLocation": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"filingLocation",
+				"fileNumber"
+			],
+			"type": "object"
+		},
+		"aboutChildSupportChangesDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"listOfSituations": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"orderDescription": {
+					"type": "string"
+				},
+				"orderStartDateReason": {
+					"type": "string"
+				},
+				"orderStartingDate": {
+					"$ref": "#/definitions/orderStartingDateInfoType"
+				}
+			},
+			"required": [
+				"orderDescription",
+				"orderStartingDate",
+				"orderStartDateReason",
+				"listOfSituations"
+			],
+			"type": "object"
+		},
+		"aboutChildSupportChangesSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutChildSupportChangesDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutChildSupportOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"listOfChildren": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"listOfSupportPayors": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"numberOf19yrsChild": {
+					"type": "number"
+				},
+				"over19Details": {
+					"items": {
+						"$ref": "#/definitions/over19DetailsInfoType"
+					},
+					"type": "array"
+				},
+				"paymentRequestStartingDate": {
+					"$ref": "#/definitions/paymentRequestStartingDateInfoType"
+				},
+				"paymentRequestStartingDateWhy": {
+					"type": "string"
+				},
+				"payorEarnsHigh": {
+					"type": "string"
+				},
+				"supportChildOver19": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[10]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[1]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[2]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[3]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[4]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[5]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[6]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[7]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[8]": {
+					"type": "string"
+				},
+				"whyOlderChildNeedSupport[9]": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"numberOf19yrsChild",
+				"listOfSupportPayors",
+				"over19Details",
+				"payorEarnsHigh",
+				"listOfChildren",
+				"supportChildOver19",
+				"paymentRequestStartingDate",
+				"paymentRequestStartingDateWhy"
+			],
+			"type": "object"
+		},
+		"aboutChildSupportOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutChildSupportOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutContactWithChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"childrenRequireContactChoices": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"conditionsDescription": {
+					"type": "string"
+				},
+				"contactTypeChoices": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"contactTypeChoicesComment": {
+					"type": "string"
+				},
+				"inPersonDetails": {
+					"type": "string"
+				},
+				"lastContactDate": {
+					"type": "string"
+				},
+				"placeConditions": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"lastContactDate",
+				"placeConditions"
+			],
+			"type": "object"
+		},
+		"aboutContactWithChildOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutContactWithChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutExistingChildSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementDate": {
+					"type": "string"
+				},
+				"agreementDifferenceType": {
+					"type": "string"
+				},
+				"changesSinceAgreement": {
+					"type": "string"
+				},
+				"changesSinceOrderList": {
+					"$ref": "#/definitions/changesSinceOrderListInfoType"
+				},
+				"orderDate": {
+					"type": "string"
+				},
+				"orderDifferenceType": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"aboutExistingChildSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutExistingChildSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutExistingSpousalSupportOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"changesSinceOrder": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"changesSinceOrder"
+			],
+			"type": "object"
+		},
+		"aboutExistingSpousalSupportOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutExistingSpousalSupportOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutPOSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutPOSurveydataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutPOSurveydataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingCourt": {
+					"type": "string"
+				},
+				"ExistingFileNumber": {
+					"type": "string"
+				},
+				"changePOattachment": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"dateOfPO": {
+					"type": "string"
+				},
+				"inCourtForPO": {
+					"type": "string"
+				},
+				"kindofPartyIbPO": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"terminateDateOfPO": {
+					"type": "string"
+				},
+				"terminatePOattachment": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"whatChangesNeeded": {
+					"type": "string"
+				},
+				"whyChangesNeeded": {
+					"type": "string"
+				},
+				"whyNotInCourt": {
+					"type": "string"
+				},
+				"whyTerminatePO": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"ExistingCourt",
+				"ExistingFileNumber",
+				"inCourtForPO",
+				"kindofPartyIbPO"
+			],
+			"type": "object"
+		},
+		"aboutParentingArrangementsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementDate": {
+					"type": "string"
+				},
+				"agreementDifferenceType": {
+					"type": "string"
+				},
+				"changesSinceAgreement": {
+					"type": "string"
+				},
+				"changesSinceOrder": {
+					"type": "string"
+				},
+				"existingType": {
+					"type": "string"
+				},
+				"orderDate": {
+					"type": "string"
+				},
+				"orderDifferenceType": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"existingType"
+			],
+			"type": "object"
+		},
+		"aboutParentingArrangementsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutParentingArrangementsDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"aboutSpousalSupportOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"howToPaySpousalSupport": {
+					"$ref": "#/definitions/howToPaySpousalSupportInfoType"
+				}
+			},
+			"required": [
+				"howToPaySpousalSupport"
+			],
+			"type": "object"
+		},
+		"aboutSpousalSupportOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/aboutSpousalSupportOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"addressInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"city": {
+					"type": "string"
+				},
+				"country": {
+					"type": "string"
+				},
+				"postcode": {
+					"type": "string"
+				},
+				"state": {
+					"type": "string"
+				},
+				"street": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"street",
+				"city",
+				"state",
+				"country",
+				"postcode"
+			],
+			"type": "object"
+		},
+		"allAnotherAdultsSharingResiInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"anotherAdultSharingResiName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"anotherAdultSharingResiRelation": {
+					"type": "string"
+				},
+				"anotheradultSharingResiDOB": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"allOtherChilderenInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"childDOB": {
+					"type": "string"
+				},
+				"childLivingWith": {
+					"type": "string"
+				},
+				"childName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"childRelationshipWithOther": {
+					"type": "string"
+				},
+				"childRelationshipWithProtected": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"childName",
+				"childDOB",
+				"childRelationshipWithProtected",
+				"childRelationshipWithOther",
+				"childLivingWith"
+			],
+			"type": "object"
+		},
+		"allchildrenInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"childDOB": {
+					"type": "string"
+				},
+				"childLivingWith": {
+					"type": "string"
+				},
+				"childName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"childRelationship": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"applicationStepOnlyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"steps": {
+					"items": {
+						"$ref": "#/definitions/stepInfoType"
+					},
+					"type": "array"
+				},
+				"types_version": {
+					"const": "1.1",
+					"type": "string"
+				}
+			},
+			"required": [
+				"steps"
+			],
+			"type": "object"
+		},
+		"backgroundSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingOrders": {
+					"type": "string"
+				},
+				"PartiesHasOtherChilderen": {
+					"type": "string"
+				},
+				"allOtherChilderen": {
+					"items": {
+						"$ref": "#/definitions/allOtherChilderenInfoType"
+					},
+					"type": "array"
+				},
+				"concernForNotObeying": {
+					"type": "string"
+				},
+				"culturalExplain": {
+					"type": "string"
+				},
+				"dateOfMarriagePO": {
+					"type": "string"
+				},
+				"describeActionsByPolice": {
+					"type": "string"
+				},
+				"describeCirumstancesPO": {
+					"type": "string"
+				},
+				"describeDisobeyOrder": {
+					"type": "string"
+				},
+				"desrcibeSWAction": {
+					"type": "string"
+				},
+				"existingPOOrders": {
+					"type": "string"
+				},
+				"explainReasonsForConcern": {
+					"type": "string"
+				},
+				"explainReasonsPO": {
+					"type": "string"
+				},
+				"howPartiesRelated": {
+					"type": "string"
+				},
+				"isSeperatedPO": {
+					"type": "string"
+				},
+				"likeToAddCulturalExplanation": {
+					"type": "string"
+				},
+				"liveTogetherPODate": {
+					"type": "string"
+				},
+				"mentalHealthConcernPO": {
+					"type": "string"
+				},
+				"otherPartyDisobeyOrder": {
+					"type": "string"
+				},
+				"reportedConcernsToPolice": {
+					"type": "string"
+				},
+				"reportedConcernsToSW": {
+					"type": "string"
+				},
+				"riskOfViolencePO": {
+					"type": "string"
+				},
+				"separationDate": {
+					"type": "string"
+				},
+				"werePOPartiesMarried": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"howPartiesRelated",
+				"werePOPartiesMarried",
+				"isSeperatedPO",
+				"likeToAddCulturalExplanation",
+				"mentalHealthConcernPO",
+				"riskOfViolencePO",
+				"existingPOOrders",
+				"otherPartyDisobeyOrder",
+				"concernForNotObeying",
+				"reportedConcernsToPolice",
+				"reportedConcernsToSW"
+			],
+			"type": "object"
+		},
+		"backgroundSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/backgroundSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"calculatingChildSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"attachingCalculations": {
+					"type": "string"
+				},
+				"whyNotAttachingCalculations": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"attachingCalculations"
+			],
+			"type": "object"
+		},
+		"calculatingChildSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/calculatingChildSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"calculatingSpousalSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"attachingCalculations": {
+					"type": "string"
+				},
+				"whyNotAttachingCalculations": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"attachingCalculations"
+			],
+			"type": "object"
+		},
+		"calculatingSpousalSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/calculatingSpousalSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"cancelGuardianDetailInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"date": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"nameOther": {
+					"type": "string"
+				},
+				"relationship": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"name",
+				"nameOther",
+				"date",
+				"relationship"
+			],
+			"type": "object"
+		},
+		"changesSinceOrderListInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"arrangementsChangedComment": {
+					"type": "string"
+				},
+				"checked": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"expensesChangedComment": {
+					"type": "string"
+				},
+				"newInformationComment": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"checked"
+			],
+			"type": "object"
+		},
+		"childDetailsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ack": {
+					"type": "string"
+				},
+				"additionalInfo": {
+					"type": "string"
+				},
+				"additionalInfoDetails": {
+					"type": "string"
+				},
+				"currentLiving": {
+					"type": "string"
+				},
+				"currentLivingComment": {
+					"type": "string"
+				},
+				"dob": {
+					"type": "string"
+				},
+				"id": {
+					"type": "number"
+				},
+				"name": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"opRelation": {
+					"type": "string"
+				},
+				"relation": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"name",
+				"dob",
+				"relation",
+				"opRelation",
+				"currentLiving"
+			],
+			"type": "object"
+		},
+		"childDetailsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"items": {
+						"$ref": "#/definitions/childDetailsDataInfoType"
+					},
+					"type": "array"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"childSupportCurrentArrangementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applicantTimeType": {
+					"type": "string"
+				},
+				"applicantTimeWithChildExplanation": {
+					"type": "string"
+				},
+				"currentArrangmentExplanation": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"applicantTimeWithChildExplanation",
+				"applicantTimeType",
+				"currentArrangmentExplanation"
+			],
+			"type": "object"
+		},
+		"childSupportCurrentArrangementsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/childSupportCurrentArrangementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"childSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applicantGuardianType": {
+					"type": "string"
+				},
+				"otherParty[0]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[10]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[1]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[2]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[3]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[4]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[5]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[6]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[7]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[8]GuardianType": {
+					"type": "string"
+				},
+				"otherParty[9]GuardianType": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"applicantGuardianType"
+			],
+			"type": "object"
+		},
+		"childSupportIncomeEarningDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"factsExplanation": {
+					"type": "string"
+				},
+				"knowFacts": {
+					"type": "string"
+				},
+				"knowIncome": {
+					"type": "string"
+				},
+				"otherPartyIncome": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"knowIncome",
+				"knowFacts"
+			],
+			"type": "object"
+		},
+		"childSupportOrderAgreementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingResponsibilityType": {
+					"type": "string"
+				},
+				"existingResponsibilityTypeComment": {
+					"type": "string"
+				},
+				"existingType": {
+					"type": "string"
+				},
+				"filedWithDirector": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"existingType"
+			],
+			"type": "object"
+		},
+		"childSupportOrderAgreementSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/childSupportOrderAgreementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"childSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/childSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"childrenSupportExpenseFieldInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"key": {
+					"type": "string"
+				},
+				"label": {
+					"type": "string"
+				},
+				"tdClass": {
+					"type": "string"
+				},
+				"thClass": {
+					"type": "string"
+				},
+				"thStyle": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"key",
+				"label",
+				"tdClass",
+				"thClass",
+				"thStyle"
+			],
+			"type": "object"
+		},
+		"contactInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"email": {
+					"type": "string"
+				},
+				"fax": {
+					"type": "string"
+				},
+				"phone": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"phone",
+				"fax",
+				"email"
+			],
+			"type": "object"
+		},
+		"contactOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementDate": {
+					"type": "string"
+				},
+				"agreementDifferenceType": {
+					"type": "string"
+				},
+				"changesSinceAgreement": {
+					"type": "string"
+				},
+				"changesSinceOrder": {
+					"type": "string"
+				},
+				"existingType": {
+					"type": "string"
+				},
+				"orderDate": {
+					"type": "string"
+				},
+				"orderDifferenceType": {
+					"type": "string"
+				},
+				"roleType": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"roleType",
+				"existingType"
+			],
+			"type": "object"
+		},
+		"contactWithChildBestInterestOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingChildBestInterestDescription": {
+					"type": "string"
+				},
+				"newChildBestInterestDescription": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"contactWithChildBestInterestsOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/contactWithChildBestInterestOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"contactWithChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"parentGuardianApplicant": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"parentGuardianApplicant"
+			],
+			"type": "object"
+		},
+		"contactWithChildOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/contactOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"contactWithChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/contactWithChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportAgreementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementDate": {
+					"type": "string"
+				},
+				"agreementDifferenceType": {
+					"type": "string"
+				},
+				"changesReasoning": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"agreementDate",
+				"changesReasoning",
+				"agreementDifferenceType"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportAgreementSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/existingSpousalSupportAgreementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportFinalOrderDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"changesSinceOrderList": {
+					"$ref": "#/definitions/spousalChangesSinceOrderListInfoType"
+				},
+				"orderDate": {
+					"type": "string"
+				},
+				"orderDifferenceType": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"orderDate",
+				"changesSinceOrderList",
+				"orderDifferenceType"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportFinalOrderSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/existingSpousalSupportFinalOrderDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportOrderAgreementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingType": {
+					"type": "string"
+				},
+				"filedWithDirector": {
+					"type": "string"
+				},
+				"fillOutForm": {
+					"type": "string"
+				},
+				"reviewableTerm": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"existingType"
+			],
+			"type": "object"
+		},
+		"existingSpousalSupportOrderAgreementSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/existingSpousalSupportOrderAgreementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"filingLocationDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingCourt": {
+					"type": "string"
+				},
+				"ExistingFamilyCase": {
+					"type": "string"
+				},
+				"ExistingFileNumber": {
+					"type": "string"
+				},
+				"ExplanationCourtLocation": {
+					"type": "boolean"
+				},
+				"MetEarlyResolutionRequirements": {
+					"type": "string"
+				},
+				"changePOattachment": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"dateOfPO": {
+					"type": "string"
+				},
+				"earlyResolutionRegistry": {
+					"type": "boolean"
+				},
+				"familyEducationProgram": {
+					"type": "boolean"
+				},
+				"familyJusticeRegistry": {
+					"type": "boolean"
+				},
+				"inCourtForPO": {
+					"type": "string"
+				},
+				"kindofPartyIbPO": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"registryLocationReason": {
+					"type": "string"
+				},
+				"terminateDateOfPO": {
+					"type": "string"
+				},
+				"terminatePOattachment": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"whatChangesNeeded": {
+					"type": "string"
+				},
+				"whyChangesNeeded": {
+					"type": "string"
+				},
+				"whyNotInCourt": {
+					"type": "string"
+				},
+				"whyTerminatePO": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"ExistingCourt",
+				"ExistingFileNumber",
+				"inCourtForPO",
+				"kindofPartyIbPO"
+			],
+			"type": "object"
+		},
+		"filingLocationSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/filingLocationDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"flmAdditionalDocsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"criminalChecked": {
+					"type": "string"
+				},
+				"isFilingAdditionalDocs": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"isFilingAdditionalDocs",
+				"criminalChecked"
+			],
+			"type": "object"
+		},
+		"flmAdditionalDocumentsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/flmAdditionalDocsDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"flmBackgroundSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingOrdersFLM": {
+					"type": "string"
+				},
+				"culturalExplain": {
+					"type": "string"
+				},
+				"dateOfMarriagePO": {
+					"type": "string"
+				},
+				"existingOrdersListFLM": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"existingPOOrders": {
+					"type": "string"
+				},
+				"howPartiesRelated": {
+					"type": "string"
+				},
+				"isSeperated": {
+					"type": "string"
+				},
+				"likeToAddCulturalExplanation": {
+					"type": "string"
+				},
+				"listOfSpouses": {
+					"type": "string"
+				},
+				"liveTogetherPODate": {
+					"type": "string"
+				},
+				"separationDate": {
+					"type": "string"
+				},
+				"werePOPartiesMarried": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"ExistingOrdersFLM",
+				"existingOrdersListFLM",
+				"existingPOOrders",
+				"howPartiesRelated",
+				"werePOPartiesMarried",
+				"liveTogetherPODate",
+				"dateOfMarriagePO",
+				"isSeperated",
+				"separationDate",
+				"likeToAddCulturalExplanation",
+				"culturalExplain"
+			],
+			"type": "object"
+		},
+		"flmBackgroundSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/flmBackgroundSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"flmQuestionnaireSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"guardianOfChildBestInterestOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"cancelGuradianChildBestInterest": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"cancelGuradianChildBestInterest"
+			],
+			"type": "object"
+		},
+		"guardianOfChildBestInterestsOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/guardianOfChildBestInterestOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"guardianOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applicationType": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"cancelGuardianDetails": {
+					"items": {
+						"$ref": "#/definitions/cancelGuardianDetailInfoType"
+					},
+					"type": "array"
+				},
+				"childrenList": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"applicationType"
+			],
+			"type": "object"
+		},
+		"guardianOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/guardianOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"howToPaySpousalSupportInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"lumpsumAmount": {
+					"type": "string"
+				},
+				"monthlyAmount": {
+					"type": "string"
+				},
+				"monthlyEndDate": {
+					"type": "string"
+				},
+				"monthlyStartDate": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"selected"
+			],
+			"type": "object"
+		},
+		"incomeAndEarningPotentialSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/childSupportIncomeEarningDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"indigenousAncestryOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ServeAcknowledgement": {
+					"type": "string"
+				},
+				"indigenousAncestry": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"indigenousChild": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"indigenousChild"
+			],
+			"type": "object"
+		},
+		"indigenousAncestryOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/indigenousAncestryOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"lawyerStatementInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"clientName": {
+					"type": "string"
+				},
+				"lawyerName": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"lawyerName",
+				"clientName"
+			],
+			"type": "object"
+		},
+		"nameInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"first": {
+					"type": "string"
+				},
+				"last": {
+					"type": "string"
+				},
+				"middle": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"first",
+				"middle",
+				"last"
+			],
+			"type": "object"
+		},
+		"noContactSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"needCommunication": {
+					"type": "string"
+				},
+				"reasonForCommunication": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"reasonForCommunicationComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"needCommunication"
+			],
+			"type": "object"
+		},
+		"noContactSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/noContactSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"noGoSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"RespondentNoGo": {
+					"type": "string"
+				},
+				"RespondentNoGoPlaces": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"RespondentNoGoPlacesComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"RespondentNoGo"
+			],
+			"type": "object"
+		},
+		"noGoSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/noGoSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"orderStartingDateInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				},
+				"startingDate": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"startingDate",
+				"selected"
+			],
+			"type": "object"
+		},
+		"otherParentingArrangementsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentalArrangementsDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"otherPartyCommonSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"items": {
+						"$ref": "#/definitions/otherPartyInfoType"
+					},
+					"type": "array"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"otherPartyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"address": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"contactInfo": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"dateOfLivedTogether": {
+					"type": "string"
+				},
+				"dateOfMarriage": {
+					"type": "string"
+				},
+				"dateSeparated": {
+					"type": "string"
+				},
+				"dob": {
+					"type": "string"
+				},
+				"id": {
+					"type": "number"
+				},
+				"knowDob": {
+					"type": "string"
+				},
+				"livedTogether": {
+					"type": "string"
+				},
+				"married": {
+					"type": "string"
+				},
+				"name": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"opRelation": {
+					"type": "string"
+				},
+				"separated": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"name",
+				"knowDob",
+				"address",
+				"contactInfo"
+			],
+			"type": "object"
+		},
+		"over19DetailsInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"reasonForSupport": {
+					"$ref": "#/definitions/reasonForSupportInfoType"
+				}
+			},
+			"required": [
+				"name",
+				"reasonForSupport"
+			],
+			"type": "object"
+		},
+		"pageInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"active": {
+					"type": "boolean"
+				},
+				"clickable": {
+					"type": "boolean"
+				},
+				"key": {
+					"type": "string"
+				},
+				"label": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"progress": {
+					"type": "number"
+				}
+			},
+			"required": [
+				"key",
+				"label",
+				"progress",
+				"active"
+			],
+			"type": "object"
+		},
+		"parentalArrangementsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"parentalArrangements": {
+					"type": "string"
+				},
+				"parentalArrangementsDescription": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"parentalArrangements",
+				"parentalArrangementsDescription"
+			],
+			"type": "object"
+		},
+		"parentalResponsibilitiesDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExplainResponsibilities": {
+					"type": "string"
+				},
+				"allResponsibilitiesOrder": {
+					"type": "string"
+				},
+				"childrenRequestedResponsibilities": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"parentalResponsibilitiesOrder": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"parentalResponsibilitiesSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentalResponsibilitiesDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingArrangementChangesDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingOrderChangeOtherTermsDescription": {
+					"type": "string"
+				},
+				"existingOrderChangeParentalResponsibilitiesDescription": {
+					"type": "string"
+				},
+				"existingOrderChangeParentingTimeConditionsDescription": {
+					"type": "string"
+				},
+				"existingOrderChangeParentingTimeDescription": {
+					"type": "string"
+				},
+				"orderChangeList": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"orderChangeList"
+			],
+			"type": "object"
+		},
+		"parentingArrangementChangesSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingArrangementChangesDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingArrangementsDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyingGuardianApplicant": {
+					"type": "string"
+				},
+				"guardianApplicant": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"guardianApplicant",
+				"applyingGuardianApplicant"
+			],
+			"type": "object"
+		},
+		"parentingArrangementsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingArrangementsDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingArrangementsbestInterestOfChildDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"existingParentingArrangementsChildBestInterestDescription": {
+					"type": "string"
+				},
+				"newParentingArrangementsChildBestInterestDescription": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"parentingArrangementsbestInterestsOfChildSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingArrangementsbestInterestOfChildDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingOrderAgreementDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyingGuardianApplicant": {
+					"type": "string"
+				},
+				"guardianApplicant": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"guardianApplicant",
+				"applyingGuardianApplicant"
+			],
+			"type": "object"
+		},
+		"parentingOrderAgreementSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingOrderAgreementDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"parentingTimeDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ApplicantParentingTimeConditions": {
+					"type": "string"
+				},
+				"RespondentParentingTimeConditions": {
+					"type": "string"
+				},
+				"applicantDesiredParentingTime": {
+					"type": "string"
+				},
+				"conditionedApplicantParentingTime": {
+					"type": "string"
+				},
+				"conditionedRespondentParentingTime": {
+					"type": "string"
+				},
+				"parentingTimeOrder": {
+					"type": "string"
+				},
+				"respondentDesiredParentingTime": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"parentingTimeOrder"
+			],
+			"type": "object"
+		},
+		"parentingTimeSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/parentingTimeDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"pathwayCompletedInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementEnfrc": {
+					"type": "boolean"
+				},
+				"caseMgmt": {
+					"type": "boolean"
+				},
+				"childReloc": {
+					"type": "boolean"
+				},
+				"familyLawMatter": {
+					"type": "boolean"
+				},
+				"priorityParenting": {
+					"type": "boolean"
+				},
+				"protectionOrder": {
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"protectionOrder",
+				"familyLawMatter",
+				"caseMgmt",
+				"priorityParenting",
+				"childReloc",
+				"agreementEnfrc"
+			],
+			"type": "object"
+		},
+		"paymentRequestStartingDateInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				},
+				"startingDate": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"startingDate",
+				"selected"
+			],
+			"type": "object"
+		},
+		"paymentScheduleInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"monthlyAmount": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"monthlyAmount",
+				"selected"
+			],
+			"type": "object"
+		},
+		"poFilingLocationSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ExistingCourt": {
+					"type": "string"
+				},
+				"ExistingFamilyCase": {
+					"type": "string"
+				},
+				"ExistingFileNumber": {
+					"type": "string"
+				},
+				"ExplanationCourtLocation": {
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"ExistingFamilyCase",
+				"ExplanationCourtLocation"
+			],
+			"type": "object"
+		},
+		"poFilingLocationSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/poFilingLocationSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"poQuestionnaireSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"PORConfirmed": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"explanationQualifying": {
+					"type": "boolean"
+				},
+				"familyUnsafe": {
+					"type": "string"
+				},
+				"orderType": {
+					"type": "string"
+				},
+				"unsafe": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"orderType"
+			],
+			"type": "object"
+		},
+		"poQuestionnaireSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/poQuestionnaireSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"protectionFromWhomSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ApplicantNeedsProtection": {
+					"type": "string"
+				},
+				"RespondentAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"RespondentContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"RespondentDOB": {
+					"type": "string"
+				},
+				"RespondentDOBExact": {
+					"type": "string"
+				},
+				"RespondentName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"allAnotherAdultsSharingResi": {
+					"items": {
+						"$ref": "#/definitions/allAnotherAdultsSharingResiInfoType"
+					},
+					"type": "array"
+				},
+				"allchildren": {
+					"items": {
+						"$ref": "#/definitions/allchildrenInfoType"
+					},
+					"type": "array"
+				},
+				"anotherAdultDOB": {
+					"type": "string"
+				},
+				"anotherAdultName": {
+					"type": "string"
+				},
+				"anotherAdultPO": {
+					"type": "string"
+				},
+				"anotherAdultReasonForPO": {
+					"type": "string"
+				},
+				"anotherAdultSharingResi": {
+					"type": "string"
+				},
+				"childPO": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"RespondentName",
+				"RespondentDOBExact",
+				"RespondentAddress",
+				"RespondentContact",
+				"ApplicantNeedsProtection",
+				"childPO"
+			],
+			"type": "object"
+		},
+		"protectionFromWhomSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/protectionFromWhomSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"questionInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"inputType": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"title": {
+					"type": "string"
+				},
+				"value": {}
+			},
+			"required": [
+				"name",
+				"value",
+				"title"
+			],
+			"type": "object"
+		},
+		"reasonForSupportInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"disability": {
+					"type": "boolean"
+				},
+				"illness": {
+					"type": "boolean"
+				},
+				"student": {
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"illness",
+				"disability",
+				"student"
+			],
+			"type": "object"
+		},
+		"removePersonSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"RespondentLiveTogether": {
+					"type": "string"
+				},
+				"needPolice": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"needPoliceComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"RespondentLiveTogether",
+				"needPolice"
+			],
+			"type": "object"
+		},
+		"removePersonSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/removePersonSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"requiredDocumentsInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"agreementEnfrc": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"caseMgmt": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"childReloc": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"familyLawMatter": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"priorityParenting": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				},
+				"protectionOrder": {
+					"$ref": "#/definitions/requiredReminderInfoType"
+				}
+			},
+			"type": "object"
+		},
+		"requiredReminderInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"reminder": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"required": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"required",
+				"reminder"
+			],
+			"type": "object"
+		},
+		"resultInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"aboutChildSupportChangesSurvey": {
+					"$ref": "#/definitions/aboutChildSupportChangesSurveyInfoType"
+				},
+				"aboutChildSupportOrderSurvey": {
+					"$ref": "#/definitions/aboutChildSupportOrderSurveyInfoType"
+				},
+				"aboutContactWithChildOrderSurvey": {
+					"$ref": "#/definitions/aboutContactWithChildOrderSurveyInfoType"
+				},
+				"aboutExistingChildSupportSurvey": {
+					"$ref": "#/definitions/aboutExistingChildSupportSurveyInfoType"
+				},
+				"aboutExistingSpousalSupportOrderSurvey": {
+					"$ref": "#/definitions/aboutExistingSpousalSupportOrderSurveyInfoType"
+				},
+				"aboutParentingArrangementsSurvey": {
+					"$ref": "#/definitions/aboutParentingArrangementsSurveyInfoType"
+				},
+				"aboutSpousalSupportOrderSurvey": {
+					"$ref": "#/definitions/aboutSpousalSupportOrderSurveyInfoType"
+				},
+				"aboutSurvey": {
+					"$ref": "#/definitions/aboutPOSurveyInfoType"
+				},
+				"applicantName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"backgroundSurvey": {
+					"$ref": "#/definitions/backgroundSurveyInfoType"
+				},
+				"bestInterestsOfChildSurvey": {
+					"$ref": "#/definitions/parentingArrangementsbestInterestsOfChildSurveyInfoType"
+				},
+				"calculatingChildSupportSurvey": {
+					"$ref": "#/definitions/calculatingChildSupportSurveyInfoType"
+				},
+				"calculatingSpousalSupportSurvey": {
+					"$ref": "#/definitions/calculatingSpousalSupportSurveyInfoType"
+				},
+				"childBestInterestAcknowledgement": {
+					"type": "boolean"
+				},
+				"childSupportCurrentArrangementsSurvey": {
+					"$ref": "#/definitions/childSupportCurrentArrangementsSurveyInfoType"
+				},
+				"childSupportOrderAgreementSurvey": {
+					"$ref": "#/definitions/childSupportOrderAgreementSurveyInfoType"
+				},
+				"childSupportSurvey": {
+					"$ref": "#/definitions/childSupportSurveyInfoType"
+				},
+				"childrenInfoSurvey": {
+					"$ref": "#/definitions/childDetailsSurveyInfoType"
+				},
+				"contactWithChildBestInterestsOfChildSurvey": {
+					"$ref": "#/definitions/contactWithChildBestInterestsOfChildSurveyInfoType"
+				},
+				"contactWithChildOrderSurvey": {
+					"$ref": "#/definitions/contactWithChildOrderSurveyInfoType"
+				},
+				"contactWithChildSurvey": {
+					"$ref": "#/definitions/contactWithChildSurveyInfoType"
+				},
+				"existingOrders": {
+					"items": {
+						"$ref": "#/definitions/ExistingOrderInfoType"
+					},
+					"type": "array"
+				},
+				"existingSpousalSupportAgreementSurvey": {
+					"$ref": "#/definitions/existingSpousalSupportAgreementSurveyInfoType"
+				},
+				"existingSpousalSupportFinalOrderSurvey": {
+					"$ref": "#/definitions/existingSpousalSupportFinalOrderSurveyInfoType"
+				},
+				"existingSpousalSupportOrderAgreementSurvey": {
+					"$ref": "#/definitions/existingSpousalSupportOrderAgreementSurveyInfoType"
+				},
+				"filingLocationSurvey": {
+					"$ref": "#/definitions/filingLocationSurveyInfoType"
+				},
+				"filingOptionsSurvey": {},
+				"flmAdditionalDocumentsSurvey": {
+					"$ref": "#/definitions/flmAdditionalDocumentsSurveyInfoType"
+				},
+				"flmBackgroundSurvey": {
+					"$ref": "#/definitions/flmBackgroundSurveyInfoType"
+				},
+				"flmQuestionnaireSurvey": {
+					"$ref": "#/definitions/flmQuestionnaireSurveyInfoType"
+				},
+				"guardianOfChildBestInterestsOfChildSurvey": {
+					"$ref": "#/definitions/guardianOfChildBestInterestsOfChildSurveyInfoType"
+				},
+				"guardianOfChildSurvey": {
+					"$ref": "#/definitions/guardianOfChildSurveyInfoType"
+				},
+				"incomeAndEarningPotentialSurvey": {
+					"$ref": "#/definitions/incomeAndEarningPotentialSurveyInfoType"
+				},
+				"indigenousAncestryOfChildSurvey": {
+					"$ref": "#/definitions/indigenousAncestryOfChildSurveyInfoType"
+				},
+				"noContactSurvey": {
+					"$ref": "#/definitions/noContactSurveyInfoType"
+				},
+				"noGoSurvey": {
+					"$ref": "#/definitions/noGoSurveyInfoType"
+				},
+				"otherParentingArrangementsSurvey": {
+					"$ref": "#/definitions/otherParentingArrangementsSurveyInfoType"
+				},
+				"otherPartyCommonSurvey": {
+					"$ref": "#/definitions/otherPartyCommonSurveyInfoType"
+				},
+				"otherPartySurvey": {
+					"$ref": "#/definitions/otherPartyCommonSurveyInfoType"
+				},
+				"parentalResponsibilitiesSurvey": {
+					"$ref": "#/definitions/parentalResponsibilitiesSurveyInfoType"
+				},
+				"parentingArrangementChangesSurvey": {
+					"$ref": "#/definitions/parentingArrangementChangesSurveyInfoType"
+				},
+				"parentingArrangementsSurvey": {
+					"$ref": "#/definitions/parentingArrangementsSurveyInfoType"
+				},
+				"parentingOrderAgreementSurvey": {
+					"$ref": "#/definitions/parentingOrderAgreementSurveyInfoType"
+				},
+				"parentingTimeSurvey": {
+					"$ref": "#/definitions/parentingTimeSurveyInfoType"
+				},
+				"pathwayCompleted": {
+					"$ref": "#/definitions/pathwayCompletedInfoType"
+				},
+				"poFilingLocationSurvey": {
+					"$ref": "#/definitions/poFilingLocationSurveyInfoType"
+				},
+				"poQuestionnaireSurvey": {
+					"$ref": "#/definitions/poQuestionnaireSurveyInfoType"
+				},
+				"protectedChildName": {
+					"items": {
+						"$ref": "#/definitions/allchildrenInfoType"
+					},
+					"type": "array"
+				},
+				"protectedPartyName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"protectionFromWhomSurvey": {
+					"$ref": "#/definitions/protectionFromWhomSurveyInfoType"
+				},
+				"removePersonSurvey": {
+					"$ref": "#/definitions/removePersonSurveyInfoType"
+				},
+				"requiredDocuments": {
+					"$ref": "#/definitions/requiredDocumentsInfoType"
+				},
+				"respondents": {
+					"items": {
+						"$ref": "#/definitions/nameInfoType"
+					},
+					"type": "array"
+				},
+				"respondentsCommon": {
+					"items": {
+						"$ref": "#/definitions/nameInfoType"
+					},
+					"type": "array"
+				},
+				"respondentsPO": {
+					"items": {
+						"$ref": "#/definitions/nameInfoType"
+					},
+					"type": "array"
+				},
+				"safetyCheckSurvey": {
+					"$ref": "#/definitions/safetyCheckSurveyInfoType"
+				},
+				"selectedForms": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"selectedPOOrder": {
+					"$ref": "#/definitions/selectedPOOrderInfoType"
+				},
+				"specialAndExtraordinaryExpensesSurvey": {
+					"$ref": "#/definitions/specialAndExtraordinaryExpensesSurveyInfoType"
+				},
+				"spousalSupportIncomeAndEarningPotentialSurvey": {
+					"$ref": "#/definitions/spousalSupportIncomeAndEarningPotentialSurveyInfoType"
+				},
+				"spousalSupportSurvey": {
+					"$ref": "#/definitions/spousalSupportSurveyInfoType"
+				},
+				"supportingDocumentForm4": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				},
+				"undueHardshipSurvey": {
+					"$ref": "#/definitions/undueHardshipSurveyInfoType"
+				},
+				"unpaidChildSupportSurvey": {
+					"$ref": "#/definitions/unpaidChildSupportSurveyInfoType"
+				},
+				"unpaidSpousalSupportSurvey": {
+					"$ref": "#/definitions/unpaidSpousalSupportSurveyInfoType"
+				},
+				"urgencySurvey": {
+					"$ref": "#/definitions/urgencySurveyInfoType"
+				},
+				"weaponsFirearmsSurvey": {
+					"$ref": "#/definitions/weaponsFirearmsSurveyInfoType"
+				},
+				"yourInformationSurvey": {
+					"$ref": "#/definitions/yourInformationSurveyInfoType"
+				},
+				"yourStorySurvey": {
+					"$ref": "#/definitions/yourStorySurveyInfoType"
+				},
+				"yourinformationPOSurvey": {
+					"$ref": "#/definitions/yourinformationPOSurveyInfoType"
+				}
+			},
+			"type": "object"
+		},
+		"safetyCheckSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"unsafe": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"unsafe"
+			],
+			"type": "object"
+		},
+		"safetyCheckSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/safetyCheckSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"selectedPOOrderInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/poQuestionnaireSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"anyOf": [
+						{
+							"items": {
+								"$ref": "#/definitions/questionInfoType"
+							},
+							"type": "array"
+						},
+						{
+							"type": "null"
+						}
+					]
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"specialAndExtraordinaryExpensesDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyForExtraordinaryExpenses": {
+					"type": "string"
+				},
+				"childrenSupportExpenseFields": {
+					"items": {
+						"$ref": "#/definitions/childrenSupportExpenseFieldInfoType"
+					},
+					"type": "array"
+				},
+				"childrenSupportExpenseItem": {
+					"items": {},
+					"type": "array"
+				}
+			},
+			"required": [
+				"applyForExtraordinaryExpenses"
+			],
+			"type": "object"
+		},
+		"specialAndExtraordinaryExpensesSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/specialAndExtraordinaryExpensesDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"spousalChangesSinceOrderListInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"checked": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"myEmploymentChangedComment": {
+					"type": "string"
+				},
+				"myHouseholdChangedComment": {
+					"type": "string"
+				},
+				"newInformationComment": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				},
+				"partyEmploymentChangedComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"myEmploymentChangedComment",
+				"partyEmploymentChangedComment",
+				"myHouseholdChangedComment",
+				"newInformationComment",
+				"otherComment",
+				"checked"
+			],
+			"type": "object"
+		},
+		"spousalPaymentScheduleInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"monthlyAmount": {
+					"type": "string"
+				},
+				"otherComment": {
+					"type": "string"
+				},
+				"selected": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"selected"
+			],
+			"type": "object"
+		},
+		"spousalSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentSupport": {
+					"type": "string"
+				},
+				"listOfReasons": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"listOfSupportPayors": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"listOfSupportPayors",
+				"currentSupport",
+				"listOfReasons"
+			],
+			"type": "object"
+		},
+		"spousalSupportIncomeAndEarningPotentialDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"factsExplanation": {
+					"type": "string"
+				},
+				"incomeAmount": {
+					"type": "string"
+				},
+				"incomeInfo": {
+					"type": "string"
+				},
+				"knowFacts": {
+					"type": "string"
+				},
+				"knowIncome": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"incomeInfo",
+				"knowIncome",
+				"knowFacts"
+			],
+			"type": "object"
+		},
+		"spousalSupportIncomeAndEarningPotentialSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/spousalSupportIncomeAndEarningPotentialDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"spousalSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/spousalSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"stepInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"active": {
+					"type": "boolean"
+				},
+				"currentPage": {
+					"type": "number"
+				},
+				"icon": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string"
+				},
+				"label": {
+					"type": "string"
+				},
+				"lastUpdate": {
+					"anyOf": [
+						{
+							"format": "date-time",
+							"type": "string"
+						},
+						{
+							"type": "null"
+						}
+					]
+				},
+				"name": {
+					"type": "string"
+				},
+				"pages": {
+					"items": {
+						"$ref": "#/definitions/pageInfoType"
+					},
+					"type": "array"
+				},
+				"result": {
+					"$ref": "#/definitions/resultInfoType"
+				},
+				"type": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"label",
+				"icon",
+				"currentPage",
+				"active",
+				"lastUpdate"
+			],
+			"type": "object"
+		},
+		"undueHardshipDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"changeAmount": {
+					"type": "string"
+				},
+				"hardshipReasons": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"hardshipReasonsComment": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"changeAmount",
+				"hardshipReasons"
+			],
+			"type": "object"
+		},
+		"undueHardshipSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/undueHardshipDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"unpaidChildSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyToReduce": {
+					"type": "string"
+				},
+				"paymentSchedule": {
+					"$ref": "#/definitions/paymentScheduleInfoType"
+				},
+				"reduceAmount": {
+					"type": "string"
+				},
+				"unPaidAmount": {
+					"type": "string"
+				},
+				"unpaid": {
+					"type": "string"
+				},
+				"whyReduceAmount": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"unpaid"
+			],
+			"type": "object"
+		},
+		"unpaidChildSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/unpaidChildSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"unpaidSpousalSupportDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"applyToReduce": {
+					"type": "string"
+				},
+				"paymentSchedule": {
+					"$ref": "#/definitions/spousalPaymentScheduleInfoType"
+				},
+				"reduceAmount": {
+					"type": "string"
+				},
+				"unPaidAmount": {
+					"type": "string"
+				},
+				"unpaid": {
+					"type": "string"
+				},
+				"whyReduceAmount": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"unpaid"
+			],
+			"type": "object"
+		},
+		"unpaidSpousalSupportSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/unpaidSpousalSupportDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"urgencySurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"PORNoNotice": {
+					"type": "string"
+				},
+				"PORWhyNoNotice": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"PORNoNotice"
+			],
+			"type": "object"
+		},
+		"urgencySurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/urgencySurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"weaponsFirearmsSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"RespondentFirearms": {
+					"type": "string"
+				},
+				"RespondentFirearmsYes": {
+					"type": "string"
+				},
+				"RespondentNoWeapons": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"RespondentWeapons": {
+					"type": "string"
+				},
+				"RespondentWeaponsYes": {
+					"type": "string"
+				},
+				"firearmsReason": {
+					"type": "string"
+				},
+				"firearmsYesReason": {
+					"type": "string"
+				},
+				"weaponsReasons": {
+					"type": "string"
+				},
+				"weaponsYesReason": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"RespondentFirearms",
+				"RespondentFirearmsYes",
+				"RespondentWeapons",
+				"RespondentWeaponsYes"
+			],
+			"type": "object"
+		},
+		"weaponsFirearmsSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/weaponsFirearmsSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"yourInformationDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ApplicantAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"ApplicantContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"ApplicantDOB": {
+					"type": "string"
+				},
+				"ApplicantName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"ApplicantOccupation": {
+					"type": "string"
+				},
+				"ExplanationServiceAddress": {
+					"type": "boolean"
+				},
+				"Lawyer": {
+					"type": "string"
+				},
+				"LawyerAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"LawyerContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"LawyerFillingOut": {
+					"type": "string"
+				},
+				"LawyerName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"lawyerStatement": {
+					"$ref": "#/definitions/lawyerStatementInfoType"
+				}
+			},
+			"required": [
+				"ApplicantName",
+				"ApplicantDOB",
+				"Lawyer"
+			],
+			"type": "object"
+		},
+		"yourInformationSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/yourInformationDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"yourStorySurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"isFamilyViolence": {
+					"type": "string"
+				},
+				"isNoneExplainedConcerns": {
+					"type": "string"
+				},
+				"noneExplainedConcerns": {
+					"type": "string"
+				},
+				"recentIncidentWithChild": {
+					"type": "string"
+				},
+				"recentIncidents": {
+					"type": "string"
+				},
+				"whatViolence": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"isFamilyViolence",
+				"isNoneExplainedConcerns",
+				"recentIncidents"
+			],
+			"type": "object"
+		},
+		"yourStorySurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/yourStorySurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		},
+		"yourinformationPOSurveyDataInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"ApplicantAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"ApplicantContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"ApplicantDOB": {
+					"type": "string"
+				},
+				"ApplicantName": {
+					"$ref": "#/definitions/nameInfoType"
+				},
+				"ApplicantOccupation": {
+					"type": "string"
+				},
+				"ExplanationServiceAddress": {
+					"type": "boolean"
+				},
+				"Lawyer": {
+					"type": "string"
+				},
+				"LawyerAddress": {
+					"$ref": "#/definitions/addressInfoType"
+				},
+				"LawyerContact": {
+					"$ref": "#/definitions/contactInfoType"
+				},
+				"LawyerName": {
+					"$ref": "#/definitions/nameInfoType"
+				}
+			},
+			"required": [
+				"ApplicantName",
+				"ApplicantDOB",
+				"Lawyer"
+			],
+			"type": "object"
+		},
+		"yourinformationPOSurveyInfoType": {
+			"additionalProperties": false,
+			"properties": {
+				"currentPage": {
+					"type": "number"
+				},
+				"currentStep": {
+					"type": "number"
+				},
+				"data": {
+					"$ref": "#/definitions/yourinformationPOSurveyDataInfoType"
+				},
+				"pageName": {
+					"type": "string"
+				},
+				"questions": {
+					"items": {
+						"$ref": "#/definitions/questionInfoType"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"data",
+				"questions",
+				"pageName",
+				"currentStep",
+				"currentPage"
+			],
+			"type": "object"
+		}
+	}
+}

--- a/tools/sort_definitions.py
+++ b/tools/sort_definitions.py
@@ -1,0 +1,8 @@
+import sys
+import json
+file = 'schema-1.0.json'
+with open(file) as f:
+    data = json.loads(f.read())
+    
+with open(file, 'w') as f:
+    json.dump(data, fp=f, sort_keys=True, indent=4)


### PR DESCRIPTION
This pull request is so we can validate some of the data in DEV/TEST/PROD (possibly make some schema corrections or additional migrations) before we push version 1.1.

/api/api/management/commands/validatesteps.py -> Used to validate steps' JSON schema via python manage.py validatesteps <schema path> 

/tools/ -> for generating fake data, generating schemas from typescript objects, testing local migrations and finally validating on new schema

