### PR TITLE
PFCF-538: Remove Robson square from FamilyJusticeRegistry

### DIFF
--- a/web/src/filters/locationRegistries.ts
+++ b/web/src/filters/locationRegistries.ts
@@ -1,7 +1,6 @@
 export const FamilyJusticeRegistries = [
     "4801",//"Kelowna Law Courts", 
     "1091", //"Nanaimo Law Courts", 
-    "2045",//"Robson Square Provincial Court"
 ];
 
 export const EarlyResolutionsRegistries = [


### PR DESCRIPTION
PFCF-538: Remove Robson square from FamilyJusticeRegistry
- location can only be part of one registry